### PR TITLE
fix: workingDir, agent isolation, and catalog separation

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -523,8 +523,9 @@ func buildSddWorkflowFixture(t *testing.T) string {
 	workflowYAML := `apiVersion: devrune/workflow/v1
 metadata:
   name: sdd
-  description: "Spec-Driven Development"
+  displayName: "SDD (Spec-Driven Development)"
   version: "1.0.0"
+  workingDir: sdd-orchestrator
 components:
   skills:
     - sdd-plan

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/davidarce/devrune/internal/model"
 	"github.com/davidarce/devrune/internal/parse"
+	"github.com/davidarce/devrune/internal/tui"
 	"github.com/davidarce/devrune/internal/tui/steps"
 	"github.com/davidarce/devrune/internal/tui/tuistyles"
 )
@@ -129,7 +131,19 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	var manifest model.UserManifest
 
-	{
+	if !nonInteractive && !hasFlags {
+		// Interactive mode: launch TUI wizard.
+		result, err := tui.Run(catalogSources)
+		if err != nil {
+			if errors.Is(err, huh.ErrUserAborted) {
+				_, _ = fmt.Fprintln(out, "Aborted.")
+				return nil
+			}
+			printError(out, "Wizard failed: "+err.Error())
+			return err
+		}
+		manifest = result.Manifest
+	} else {
 		// Non-interactive / flag-based path.
 		// Merge catalog sources into --source flag values. Explicit --source flags are
 		// added first; catalog sources are appended if not already present.

--- a/internal/materialize/materializer.go
+++ b/internal/materialize/materializer.go
@@ -289,21 +289,16 @@ func (m *Materializer) Install(
 				return fmt.Errorf("materializer: load workflow manifest %q: %w", wf.Name, err)
 			}
 
-			// Skip workflow skill installation for this agent if its skill directory
-			// was already populated by a prior agent in the loop.
-			if !skillAlreadyRendered {
-				wfResult, err := renderer.InstallWorkflow(wfManifest, wfDir, agentWorkspace)
-				if err != nil {
-					return fmt.Errorf("materializer: install workflow %q for agent %q: %w",
-						wf.Name, agentRef.Name, err)
-				}
-				// Use renderer-reported managed paths exclusively. All built-in renderers
-				// (Claude, Factory, OpenCode, Copilot) return the actual installed paths
-				// via WorkflowInstallResult.ManagedPaths. Custom renderers that have not
-				// yet implemented the contract will simply add no workflow paths here,
-				// which is safe — they opt in by returning ManagedPaths.
-				managedPaths = append(managedPaths, wfResult.ManagedPaths...)
+			// Always call InstallWorkflow for every renderer, even when the
+			// shared skill directory was already populated by a prior agent.
+			// Renderers are idempotent for file writes, and per-renderer
+			// synthesis (e.g. opencode.json agent entries) must always run.
+			wfResult, err := renderer.InstallWorkflow(wfManifest, wfDir, agentWorkspace)
+			if err != nil {
+				return fmt.Errorf("materializer: install workflow %q for agent %q: %w",
+					wf.Name, agentRef.Name, err)
 			}
+			managedPaths = append(managedPaths, wfResult.ManagedPaths...)
 			installedWorkflows = append(installedWorkflows, wfManifest)
 			// Accumulate for cross-agent root catalog (deduplicated by name).
 			if !containsString(allWorkflowNames, wfManifest.Metadata.Name) {
@@ -335,51 +330,69 @@ func (m *Materializer) Install(
 		activeAgents = append(activeAgents, agentRef.Name)
 	}
 
-	// Step 8 (post-loop): Collect mcpInstructions and registryContents from all renderers.
+	// Step 8 (post-loop): Collect mcpInstructions and per-agent registryContents.
+	// Claude gets its own registry content (with .claude/ paths); all other agents
+	// share AGENTS.md registry content (with .agents/ paths from the first non-claude renderer).
 	mcpInstructions := make(map[string]string)
-	registryContents := make(map[string]string)
+	claudeRegistryContents := make(map[string]string)
+	agentsRegistryContents := make(map[string]string)
 	for _, agentRef := range agents {
 		renderer, ok := m.renderers[agentRef.Name]
 		if !ok {
 			continue
 		}
-		if cc, ok := renderer.(catalogContributor); ok {
-			for k, v := range cc.MCPAgentInstructions() {
-				if _, exists := mcpInstructions[k]; !exists {
-					mcpInstructions[k] = v
-				}
+		cc, ok := renderer.(catalogContributor)
+		if !ok {
+			continue
+		}
+		for k, v := range cc.MCPAgentInstructions() {
+			if _, exists := mcpInstructions[k]; !exists {
+				mcpInstructions[k] = v
 			}
-			for k, v := range cc.RegistryContents() {
-				if _, exists := registryContents[k]; !exists {
-					registryContents[k] = v
-				}
+		}
+		target := agentsRegistryContents
+		if agentRef.Name == "claude" {
+			target = claudeRegistryContents
+		}
+		for k, v := range cc.RegistryContents() {
+			if _, exists := target[k]; !exists {
+				target[k] = v
 			}
 		}
 	}
 
-	// T022: Remove old workspace catalog files before writing root catalog.
+	// T022: Remove old workspace catalog files and stale symlink.
 	for _, old := range []string{
 		filepath.Join(projectRoot, ".claude", "CLAUDE.md"),
 		filepath.Join(projectRoot, ".opencode", "AGENTS.md"),
 		filepath.Join(projectRoot, ".factory", "AGENTS.md"),
 		filepath.Join(projectRoot, ".github", "copilot-instructions.md"),
 	} {
-		_ = os.Remove(old) // ignore errors — files may not exist
+		_ = os.Remove(old)
+	}
+	// Remove stale symlink if CLAUDE.md points to AGENTS.md (legacy).
+	claudePath := filepath.Join(projectRoot, "CLAUDE.md")
+	if linfo, err := os.Lstat(claudePath); err == nil && linfo.Mode()&os.ModeSymlink != 0 {
+		_ = os.Remove(claudePath)
 	}
 
-	// T021: Generate root catalog AGENTS.md with all skills/rules/workflows.
-	catalogContent, err := renderers.RenderRootCatalog(allSkills, allRules, allWorkflows, mcpInstructions, registryContents)
+	// T021: Generate CLAUDE.md with Claude-specific paths.
+	claudeCatalog, err := renderers.RenderRootCatalog(allSkills, allRules, allWorkflows, mcpInstructions, claudeRegistryContents)
 	if err != nil {
-		return fmt.Errorf("materializer: render root catalog: %w", err)
+		return fmt.Errorf("materializer: render CLAUDE.md catalog: %w", err)
+	}
+	if err := renderers.WriteManagedBlock(claudePath, renderers.CatalogBeginMarker, renderers.CatalogEndMarker, claudeCatalog); err != nil {
+		return fmt.Errorf("materializer: write CLAUDE.md: %w", err)
+	}
+
+	// Generate AGENTS.md with .agents/ paths for factory, codex, opencode, copilot.
+	agentsCatalog, err := renderers.RenderRootCatalog(allSkills, allRules, allWorkflows, mcpInstructions, agentsRegistryContents)
+	if err != nil {
+		return fmt.Errorf("materializer: render AGENTS.md catalog: %w", err)
 	}
 	agentsPath := filepath.Join(projectRoot, "AGENTS.md")
-	if err := renderers.WriteManagedBlock(agentsPath, renderers.CatalogBeginMarker, renderers.CatalogEndMarker, catalogContent); err != nil {
-		return fmt.Errorf("materializer: write root AGENTS.md: %w", err)
-	}
-	claudePath := filepath.Join(projectRoot, "CLAUDE.md")
-	if err := renderers.CreateSymlinkOrCopy(agentsPath, claudePath); err != nil {
-		// Non-fatal: warn but don't block install (e.g. user has a custom CLAUDE.md).
-		_, _ = fmt.Fprintf(os.Stderr, "materializer: warning: create CLAUDE.md symlink: %v\n", err)
+	if err := renderers.WriteManagedBlock(agentsPath, renderers.CatalogBeginMarker, renderers.CatalogEndMarker, agentsCatalog); err != nil {
+		return fmt.Errorf("materializer: write AGENTS.md: %w", err)
 	}
 
 	// Step 6.5: Ensure project-root .mcp.json exists for any MCP-enabled install.

--- a/internal/materialize/materializer_test.go
+++ b/internal/materialize/materializer_test.go
@@ -1354,8 +1354,9 @@ func TestMaterializer_Install_CLAUDEmd_NotRemovedIfUserOwned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CLAUDE.md should still exist: %v", err)
 	}
-	if string(data) != userContent {
-		t.Errorf("user-owned CLAUDE.md should not be overwritten; got:\n%s", string(data))
+	// User content should be preserved alongside the managed block.
+	if !strings.Contains(string(data), "My custom instructions") {
+		t.Errorf("user-owned CLAUDE.md content should be preserved; got:\n%s", string(data))
 	}
 
 	// AGENTS.md must still exist at project root.

--- a/internal/materialize/renderers/catalog.go
+++ b/internal/materialize/renderers/catalog.go
@@ -45,10 +45,7 @@ func RenderRootCatalog(
 	if len(workflows) > 0 {
 		sb.WriteString("## Workflows\n\n")
 		for _, wf := range workflows {
-			_, _ = fmt.Fprintf(&sb, "### %s\n\n", wf.Metadata.Name)
-			if wf.Metadata.Description != "" {
-				sb.WriteString(wf.Metadata.Description + "\n\n")
-			}
+			_, _ = fmt.Fprintf(&sb, "### %s\n\n", wf.Metadata.EffectiveDisplayName())
 			if len(wf.Components.Commands) > 0 {
 				sb.WriteString("| Command | Action |\n")
 				sb.WriteString("|---------|--------|\n")

--- a/internal/materialize/renderers/catalog_test.go
+++ b/internal/materialize/renderers/catalog_test.go
@@ -136,7 +136,7 @@ func TestRenderRootCatalog_WithWorkflows(t *testing.T) {
 		{
 			Metadata: model.WorkflowMetadata{
 				Name:        "sdd",
-				Description: "Spec-Driven Development workflow: explore, plan, implement, review.",
+				DisplayName: "SDD (Spec-Driven Development)",
 			},
 			Components: model.WorkflowComponents{
 				DecisionRules: []model.DecisionRule{
@@ -160,11 +160,8 @@ func TestRenderRootCatalog_WithWorkflows(t *testing.T) {
 	if !strings.Contains(out, "## Workflows") {
 		t.Errorf("output missing Workflows section")
 	}
-	if !strings.Contains(out, "### sdd") {
+	if !strings.Contains(out, "### SDD (Spec-Driven Development)") {
 		t.Errorf("output missing sdd workflow heading")
-	}
-	if !strings.Contains(out, "Spec-Driven Development workflow") {
-		t.Errorf("output missing workflow description")
 	}
 	if !strings.Contains(out, "## Decision Rules") {
 		t.Errorf("output missing Decision Rules section")

--- a/internal/materialize/renderers/claude.go
+++ b/internal/materialize/renderers/claude.go
@@ -210,7 +210,7 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 		skillsSet[s] = true
 	}
 
-	destBase := filepath.Join(workspaceRoot, r.def.SkillDir, wf.Metadata.Name)
+	destBase := filepath.Join(workspaceRoot, r.def.SkillDir, wf.Metadata.EffectiveWorkingDir())
 	if err := os.MkdirAll(destBase, 0o755); err != nil {
 		return matypes.WorkflowInstallResult{}, fmt.Errorf("claude: workflow mkdir %q: %w", destBase, err)
 	}
@@ -266,7 +266,7 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 
 	// Build shared placeholder replacements: {SKILLS_PATH} and {SDD_MODEL_*}.
 	// Hoisted outside the registry block so postProcessWorkflow can use it too.
-	replacements := buildWorkflowPlaceholderReplacements(wf, r.def.Workspace, r.def.SkillDir+"/"+wf.Metadata.Name, nil, r.modelOverrides)
+	replacements := buildWorkflowPlaceholderReplacements(wf, r.def.Workspace, r.def.SkillDir, nil, r.modelOverrides, nil)
 
 	// T021: Load registry content if declared in the workflow manifest.
 	if wf.Components.Registry != "" {

--- a/internal/materialize/renderers/claude_test.go
+++ b/internal/materialize/renderers/claude_test.go
@@ -533,15 +533,15 @@ components:
 	}
 }
 
-// TestClaudeRenderer_InstallWorkflow_ReplacesSkillsPath verifies that {SKILLS_PATH}
-// in an ORCHESTRATOR.md file is replaced with the actual workspace-relative path.
+// TestClaudeRenderer_InstallWorkflow_ReplacesPlaceholders verifies that {SKILLS_PATH}
+// and {WORKFLOW_DIR} in an ORCHESTRATOR.md file are replaced with actual paths.
 func TestClaudeRenderer_InstallWorkflow_ReplacesSkillsPath(t *testing.T) {
 	r := renderers.NewClaudeRenderer(claudeAgentDef())
 
-	// Create a temporary workflow directory with an ORCHESTRATOR.md containing {SKILLS_PATH}.
+	// Create a temporary workflow directory with an ORCHESTRATOR.md containing placeholders.
 	wfCacheDir := t.TempDir()
 
-	orchestratorContent := "# Orchestrator\n\nSkills path: {SKILLS_PATH}\n"
+	orchestratorContent := "# Orchestrator\n\nSkills: {SKILLS_PATH}\nWorkflow: {WORKFLOW_DIR}\n"
 	if err := os.WriteFile(filepath.Join(wfCacheDir, "ORCHESTRATOR.md"), []byte(orchestratorContent), 0o644); err != nil {
 		t.Fatalf("write ORCHESTRATOR.md: %v", err)
 	}
@@ -583,9 +583,12 @@ components:
 	if strings.Contains(content, "{SKILLS_PATH}") {
 		t.Errorf("{SKILLS_PATH} was not replaced; ORCHESTRATOR.md content:\n%s", content)
 	}
-	// The replacement should contain the workflow name in the path.
-	if !strings.Contains(content, "sdd") {
-		t.Errorf("replaced skills path does not reference workflow name; content:\n%s", content)
+	if strings.Contains(content, "{WORKFLOW_DIR}") {
+		t.Errorf("{WORKFLOW_DIR} was not replaced; ORCHESTRATOR.md content:\n%s", content)
+	}
+	// SKILLS_PATH is the base skills directory; WORKFLOW_DIR includes the workingDir (defaults to name "sdd").
+	if !strings.Contains(content, "skills/sdd") {
+		t.Errorf("replaced workflow dir does not reference workflow workingDir; content:\n%s", content)
 	}
 }
 
@@ -666,8 +669,8 @@ func TestClaudeRenderer_InstallWorkflow_RegistryNoDoubleSlash(t *testing.T) {
 
 	wfCacheDir := t.TempDir()
 
-	// REGISTRY.md uses {SKILLS_PATH}/ORCHESTRATOR.md — matching the real catalog template.
-	registryContent := "Full orchestrator instructions: {SKILLS_PATH}/ORCHESTRATOR.md\n"
+	// REGISTRY.md uses {WORKFLOW_DIR}/ORCHESTRATOR.md — matching the real catalog template.
+	registryContent := "Full orchestrator instructions: {WORKFLOW_DIR}/ORCHESTRATOR.md\n"
 	if err := os.WriteFile(filepath.Join(wfCacheDir, "REGISTRY.md"), []byte(registryContent), 0o644); err != nil {
 		t.Fatalf("write REGISTRY.md: %v", err)
 	}
@@ -696,10 +699,10 @@ func TestClaudeRenderer_InstallWorkflow_RegistryNoDoubleSlash(t *testing.T) {
 	if strings.Contains(content, "//") {
 		t.Errorf("double slash found in registry content; got:\n%s", content)
 	}
-	if strings.Contains(content, "{SKILLS_PATH}") {
-		t.Errorf("{SKILLS_PATH} was not resolved; got:\n%s", content)
+	if strings.Contains(content, "{WORKFLOW_DIR}") {
+		t.Errorf("{WORKFLOW_DIR} was not resolved; got:\n%s", content)
 	}
-	// Path must resolve to skills/sdd/ORCHESTRATOR.md — no spurious sdd-orchestrator/ subdir.
+	// Path must resolve to skills/sdd/ORCHESTRATOR.md — workingDir defaults to name "sdd".
 	wantSuffix := "skills/sdd/ORCHESTRATOR.md"
 	if !strings.Contains(content, wantSuffix) {
 		t.Errorf("expected path containing %q; got:\n%s", wantSuffix, content)

--- a/internal/materialize/renderers/codex.go
+++ b/internal/materialize/renderers/codex.go
@@ -230,6 +230,7 @@ func (r *CodexRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath str
 	}
 
 	skillsBase := filepath.Join(workspaceRoot, r.def.SkillDir)
+	workflowDir := filepath.Join(skillsBase, wf.Metadata.EffectiveWorkingDir())
 
 	if err := os.MkdirAll(skillsBase, 0o755); err != nil {
 		return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: workflow mkdir skills: %w", err)
@@ -269,22 +270,20 @@ func (r *CodexRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath str
 		}
 
 		if name == wf.Components.Entrypoint {
-			// Orchestrator: .agents/skills/<wf-name>-orchestrator/ORCHESTRATOR.md
-			orchDirName := wf.Metadata.Name + "-orchestrator"
-			orchDir := filepath.Join(skillsBase, orchDirName)
-			if err := os.MkdirAll(orchDir, 0o755); err != nil {
+			// Orchestrator: .agents/skills/<workingDir>/ORCHESTRATOR.md
+			if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: mkdir orchestrator: %w", err)
 			}
-			dstPath := filepath.Join(orchDir, name)
+			dstPath := filepath.Join(workflowDir, name)
 			if err := copySingleFile(srcPath, dstPath, 0o644); err != nil {
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: workflow entrypoint: %w", err)
 			}
-			managedPaths = append(managedPaths, orchDir)
+			managedPaths = append(managedPaths, workflowDir)
 			continue
 		}
 
-		// Copy everything else (e.g. _shared/) as-is under skillsBase.
-		dstPath := filepath.Join(skillsBase, name)
+		// Copy everything else (e.g. _shared/) as-is under workflowDir.
+		dstPath := filepath.Join(workflowDir, name)
 		if err := copyEntry(srcPath, dstPath, entry); err != nil {
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: workflow copy %q: %w", name, err)
 		}
@@ -294,7 +293,7 @@ func (r *CodexRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath str
 	// Build shared placeholder replacements: {SKILLS_PATH} only.
 	// Codex does not support model routing in the TUI, so {SDD_MODEL_*} placeholders
 	// are removed entirely by removeModelPlaceholderLines below.
-	replacements := buildWorkflowPathReplacements(workspaceRoot, r.def.SkillDir)
+	replacements := buildWorkflowPathReplacements(wf, workspaceRoot, r.def.SkillDir)
 
 	// Capture registry content for catalog injection; apply shared replacements.
 	if wf.Components.Registry != "" {

--- a/internal/materialize/renderers/copilot.go
+++ b/internal/materialize/renderers/copilot.go
@@ -332,6 +332,7 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	}
 
 	skillsBase := filepath.Join(workspaceRoot, r.def.SkillDir)
+	workflowDirPath := filepath.Join(skillsBase, wf.Metadata.EffectiveWorkingDir())
 	if err := os.MkdirAll(skillsBase, 0o755); err != nil {
 		return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: workflow mkdir skills: %w", err)
 	}
@@ -360,7 +361,15 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	if agentSkillDir == "" {
 		agentSkillDir = r.def.SkillDir
 	}
-	replacements := buildWorkflowPathReplacements(workspaceRoot, agentSkillDir)
+	replacements := buildWorkflowPathReplacements(wf, workspaceRoot, agentSkillDir)
+	// Override subagent placeholders to use role names (Copilot has native .agent.md agents).
+	for _, role := range wf.Components.Roles {
+		if role.Kind != "subagent" {
+			continue
+		}
+		key := model.PlaceholderKeyFromRole(wf.Metadata.Name, role.Name, role.Placeholder)
+		replacements["{WORKFLOW_SUBAGENT_"+key+"}"] = role.Name
+	}
 
 	var managedPaths []string
 
@@ -379,7 +388,7 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 
 		// T019: Install the orchestrator entrypoint as a native .agent.md with frontmatter.
 		if name == wf.Components.Entrypoint {
-			orchRoleName := wf.Metadata.Name + "-orchestrator"
+			orchRoleName := wf.Metadata.EffectiveWorkingDir()
 			if orchRole := findWorkflowRoleByKind(wf.Components.Roles, "orchestrator"); orchRole != nil {
 				orchRoleName = orchRole.Name
 			}
@@ -410,9 +419,8 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 			continue
 		}
 
-		// Copy everything else (e.g. _shared/) as-is under skillsBase.
-		// T016: _shared/ goes to skills/_shared/, NOT agents/_shared/.
-		dstPath := filepath.Join(skillsBase, name)
+		// Copy everything else (e.g. _shared/) as-is under workflowDir.
+		dstPath := filepath.Join(workflowDirPath, name)
 		if err := copyEntry(srcPath, dstPath, entry); err != nil {
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: workflow copy %q: %w", name, err)
 		}
@@ -480,8 +488,8 @@ func (r *CopilotRenderer) installOrchestratorAgent(srcPath, dstPath string, wf m
 	}
 
 	// Derive the orchestrator role name from the workflow roles.
-	orchRoleName := wf.Metadata.Name + "-orchestrator"
-	orchDesc := "SDD Orchestrator — coordinates " + wf.Metadata.Name + " workflow via sub-agents"
+	orchRoleName := wf.Metadata.EffectiveWorkingDir()
+	orchDesc := "SDD Orchestrator — coordinates " + wf.Metadata.EffectiveDisplayName() + " workflow via sub-agents"
 	if orchRole := findWorkflowRoleByKind(wf.Components.Roles, "orchestrator"); orchRole != nil {
 		orchRoleName = orchRole.Name
 	}

--- a/internal/materialize/renderers/copilot_test.go
+++ b/internal/materialize/renderers/copilot_test.go
@@ -377,7 +377,7 @@ func TestCopilotRenderer_InstallWorkflow_SkillsUnderSkillsDir(t *testing.T) {
 
 	wf := model.WorkflowManifest{
 		APIVersion: "devrune/workflow/v1",
-		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0", WorkingDir: "sdd-orchestrator"},
 		Components: model.WorkflowComponents{
 			Skills:     []string{"sdd-plan"},
 			Entrypoint: "ORCHESTRATOR.md",
@@ -398,8 +398,8 @@ func TestCopilotRenderer_InstallWorkflow_SkillsUnderSkillsDir(t *testing.T) {
 		t.Errorf("expected %s to exist: %v", skillMD, err)
 	}
 
-	// POSITIVE: _shared directory under skills/
-	sharedDest := filepath.Join(workspaceRoot, "skills", "_shared")
+	// POSITIVE: _shared directory under skills/sdd-orchestrator/ (workflowDir)
+	sharedDest := filepath.Join(workspaceRoot, "skills", "sdd-orchestrator", "_shared")
 	if info, err := os.Stat(sharedDest); err != nil || !info.IsDir() {
 		t.Errorf("expected %s to be a directory: err=%v", sharedDest, err)
 	}
@@ -454,7 +454,7 @@ func TestCopilotRenderer_InstallWorkflow_OrchestratorOnlyInAgentsDir(t *testing.
 
 	wf := model.WorkflowManifest{
 		APIVersion: "devrune/workflow/v1",
-		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0", WorkingDir: "sdd-orchestrator"},
 		Components: model.WorkflowComponents{
 			Skills:     []string{"sdd-plan"},
 			Entrypoint: "ORCHESTRATOR.md",
@@ -509,7 +509,7 @@ func TestCopilotRenderer_InstallWorkflow_RegistryInjectedIntoCatalog(t *testing.
 
 	wf := model.WorkflowManifest{
 		APIVersion: "devrune/workflow/v1",
-		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0", WorkingDir: "sdd-orchestrator"},
 		Components: model.WorkflowComponents{
 			Skills:   []string{"sdd-explore"},
 			Registry: "REGISTRY.md",
@@ -639,7 +639,7 @@ func TestCopilotRenderer_InstallWorkflow_ManagedPathsNonEmpty(t *testing.T) {
 
 	wf := model.WorkflowManifest{
 		APIVersion: "devrune/workflow/v1",
-		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0", WorkingDir: "sdd-orchestrator"},
 		Components: model.WorkflowComponents{
 			Skills:     []string{"sdd-plan"},
 			Entrypoint: "ORCHESTRATOR.md",

--- a/internal/materialize/renderers/export_test.go
+++ b/internal/materialize/renderers/export_test.go
@@ -17,7 +17,7 @@ var BuildWorkflowPlaceholderReplacements = func(
 	modelResolver func(string) string,
 	modelOverrides map[string]string,
 ) map[string]string {
-	return buildWorkflowPlaceholderReplacements(wf, workspaceDir, skillDir, modelResolver, modelOverrides)
+	return buildWorkflowPlaceholderReplacements(wf, workspaceDir, skillDir, modelResolver, modelOverrides, nil)
 }
 
 // BuildWorkflowPathReplacements re-exports buildWorkflowPathReplacements

--- a/internal/materialize/renderers/factory.go
+++ b/internal/materialize/renderers/factory.go
@@ -237,6 +237,7 @@ func (r *FactoryRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	}
 
 	skillsBase := filepath.Join(workspaceRoot, r.def.SkillDir)
+	workflowDir := filepath.Join(skillsBase, wf.Metadata.EffectiveWorkingDir())
 
 	if err := os.MkdirAll(skillsBase, 0o755); err != nil {
 		return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: workflow mkdir skills: %w", err)
@@ -276,22 +277,20 @@ func (r *FactoryRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 		}
 
 		if name == wf.Components.Entrypoint {
-			// Orchestrator: .factory/skills/<wf-name>-orchestrator/ORCHESTRATOR.md
-			orchDirName := wf.Metadata.Name + "-orchestrator"
-			orchDir := filepath.Join(skillsBase, orchDirName)
-			if err := os.MkdirAll(orchDir, 0o755); err != nil {
+			// Orchestrator: .factory/skills/<workingDir>/ORCHESTRATOR.md
+			if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: mkdir orchestrator: %w", err)
 			}
-			dstPath := filepath.Join(orchDir, name)
+			dstPath := filepath.Join(workflowDir, name)
 			if err := copySingleFile(srcPath, dstPath, 0o644); err != nil {
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: workflow entrypoint: %w", err)
 			}
-			managedPaths = append(managedPaths, orchDir)
+			managedPaths = append(managedPaths, workflowDir)
 			continue
 		}
 
-		// Copy everything else (e.g. _shared/) as-is under skillsBase.
-		dstPath := filepath.Join(skillsBase, name)
+		// Copy everything else (e.g. _shared/) as-is under workflowDir.
+		dstPath := filepath.Join(workflowDir, name)
 		if err := copyEntry(srcPath, dstPath, entry); err != nil {
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: workflow copy %q: %w", name, err)
 		}
@@ -304,7 +303,7 @@ func (r *FactoryRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	// removeModelPlaceholderLines below. This prevents invalid model IDs from being
 	// written into the installed ORCHESTRATOR.md, allowing sub-agents to inherit the
 	// session's active model instead.
-	replacements := buildWorkflowPathReplacements(workspaceRoot, r.def.SkillDir)
+	replacements := buildWorkflowPathReplacements(wf, workspaceRoot, r.def.SkillDir)
 
 	// Capture registry content for catalog injection; apply shared replacements.
 	if wf.Components.Registry != "" {

--- a/internal/materialize/renderers/factory_test.go
+++ b/internal/materialize/renderers/factory_test.go
@@ -315,7 +315,7 @@ func setupFactoryWorkflowFixture(t *testing.T) string {
 func sddWorkflowManifest() model.WorkflowManifest {
 	return model.WorkflowManifest{
 		APIVersion: "devrune/workflow/v1",
-		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0", WorkingDir: "sdd-orchestrator"},
 		Components: model.WorkflowComponents{
 			Skills:     []string{"sdd-plan"},
 			Entrypoint: "ORCHESTRATOR.md",
@@ -370,10 +370,10 @@ func TestFactoryRenderer_InstallWorkflow_SkillsInCorrectLocation(t *testing.T) {
 		t.Errorf("expected sdd-orchestrator/ORCHESTRATOR.md but got: %v", err)
 	}
 
-	// Positive: _shared directory copied under skillsBase.
-	sharedDir := filepath.Join(agentsSkillsDir, "_shared")
+	// Positive: _shared directory copied under workflowDir (sdd-orchestrator).
+	sharedDir := filepath.Join(agentsSkillsDir, "sdd-orchestrator", "_shared")
 	if _, err := os.Stat(sharedDir); err != nil {
-		t.Errorf("expected _shared/ directory under .agents/skills but got: %v", err)
+		t.Errorf("expected _shared/ directory under .agents/skills/sdd-orchestrator but got: %v", err)
 	}
 
 	// Positive: ManagedPaths is non-empty.

--- a/internal/materialize/renderers/helpers.go
+++ b/internal/materialize/renderers/helpers.go
@@ -561,7 +561,9 @@ func resolveMCPDefDir(cacheRoot, dir string) string {
 // bugs and unresolved model placeholder markers.
 //
 // Produced replacements:
-//   - {SKILLS_PATH} → "<workspaceDir>/<skillDir>" (no trailing slash)
+//   - {SKILLS_PATH} → "<workspaceDir>/<skillDir>" (base skills directory)
+//   - {WORKFLOW_DIR} → "<workspaceDir>/<skillDir>/<workingDir>" (workflow files directory)
+//   - {WORKFLOW_SUBAGENT_<KEY>} → subagent type for each subagent role
 //   - {WORKFLOW_MODEL_<KEY>} → resolved model value for each subagent role
 //   - {SDD_MODEL_*} legacy aliases when wf.Metadata.Name == "sdd"
 //
@@ -590,18 +592,26 @@ func buildWorkflowPlaceholderReplacements(
 	skillDir string,
 	modelResolver func(string) string,
 	modelOverrides map[string]string,
+	subagentResolver func(roleName string) string,
 ) map[string]string {
 	// Normalise: strip trailing slashes so joins are always clean.
 	workspaceDir = strings.TrimRight(workspaceDir, "/")
 	skillDir = strings.TrimRight(skillDir, "/")
 
-	skillsPath := workspaceDir + "/" + skillDir
+	skillsPath := filepath.Clean(workspaceDir + "/" + skillDir)
 	if skillDir == "" {
 		skillsPath = workspaceDir
 	}
 
+	workingDir := wf.Metadata.EffectiveWorkingDir()
+	workflowDir := filepath.Clean(skillsPath + "/" + workingDir)
+	if workingDir == "" {
+		workflowDir = skillsPath
+	}
+
 	replacements := map[string]string{
-		"{SKILLS_PATH}": skillsPath,
+		"{SKILLS_PATH}":  skillsPath,
+		"{WORKFLOW_DIR}": workflowDir,
 	}
 
 	wfName := wf.Metadata.Name
@@ -620,6 +630,17 @@ func buildWorkflowPlaceholderReplacements(
 		if role.Kind != "subagent" {
 			continue
 		}
+
+		key := model.PlaceholderKeyFromRole(wfName, role.Name, role.Placeholder)
+
+		// Emit subagent type placeholder for every subagent role (regardless of model).
+		// When subagentResolver is nil, defaults to "general" (Claude Code Agent tool).
+		// When provided, resolves to platform-specific agent name (e.g. "sdd-explorer" for OpenCode).
+		subagentType := "general"
+		if subagentResolver != nil {
+			subagentType = subagentResolver(role.Name)
+		}
+		replacements["{WORKFLOW_SUBAGENT_"+key+"}"] = subagentType
 
 		// Check TUI-selected override first, then fall back to role.Model from workflow.yaml.
 		modelValue := ""
@@ -640,7 +661,6 @@ func buildWorkflowPlaceholderReplacements(
 			resolved = modelResolver(modelValue)
 		}
 
-		key := model.PlaceholderKeyFromRole(wfName, role.Name, role.Placeholder)
 		replacements["{WORKFLOW_MODEL_"+key+"}"] = resolved
 
 		// Emit legacy SDD aliases for backward compatibility.
@@ -655,23 +675,39 @@ func buildWorkflowPlaceholderReplacements(
 }
 
 // buildWorkflowPathReplacements constructs a minimal replacement map containing
-// only the {SKILLS_PATH} placeholder. It is used by renderers that do not support
-// model routing (Factory, Copilot) so that model placeholders are never resolved
-// from workflow role metadata. The caller is responsible for removing unresolved
-// model placeholder lines from installed files via removeModelPlaceholderLines
-// after calling resolvePlaceholders.
+// only the {SKILLS_PATH} and {WORKFLOW_DIR} placeholders. It is used by renderers
+// that do not support model routing (Factory, Copilot) so that model placeholders
+// are never resolved from workflow role metadata. The caller is responsible for
+// removing unresolved model placeholder lines from installed files via
+// removeModelPlaceholderLines after calling resolvePlaceholders.
 //
 // workspaceDir and skillDir must not have trailing slashes.
-func buildWorkflowPathReplacements(workspaceDir, skillDir string) map[string]string {
+func buildWorkflowPathReplacements(wf model.WorkflowManifest, workspaceDir, skillDir string) map[string]string {
 	workspaceDir = strings.TrimRight(workspaceDir, "/")
 	skillDir = strings.TrimRight(skillDir, "/")
-	skillsPath := workspaceDir + "/" + skillDir
+	skillsPath := filepath.Clean(workspaceDir + "/" + skillDir)
 	if skillDir == "" {
 		skillsPath = workspaceDir
 	}
-	return map[string]string{
-		"{SKILLS_PATH}": skillsPath,
+	workingDir := wf.Metadata.EffectiveWorkingDir()
+	workflowDir := filepath.Clean(skillsPath + "/" + workingDir)
+	if workingDir == "" {
+		workflowDir = skillsPath
 	}
+	replacements := map[string]string{
+		"{SKILLS_PATH}":  skillsPath,
+		"{WORKFLOW_DIR}": workflowDir,
+	}
+	// Add subagent placeholders defaulting to "general" for renderers without native agents.
+	wfName := wf.Metadata.Name
+	for _, role := range wf.Components.Roles {
+		if role.Kind != "subagent" {
+			continue
+		}
+		key := model.PlaceholderKeyFromRole(wfName, role.Name, role.Placeholder)
+		replacements["{WORKFLOW_SUBAGENT_"+key+"}"] = "general"
+	}
+	return replacements
 }
 
 // removeModelPlaceholderLines walks all .md files under rootDir and removes any

--- a/internal/materialize/renderers/helpers_test.go
+++ b/internal/materialize/renderers/helpers_test.go
@@ -907,11 +907,11 @@ func TestBuildWorkflowPlaceholderReplacements_OpenCodeResolver(t *testing.T) {
 
 // TestBuildWorkflowPathReplacements_OnlySkillsPath verifies that the function
 // returns only a {SKILLS_PATH} entry and no {SDD_MODEL_*} entries.
-func TestBuildWorkflowPathReplacements_OnlySkillsPath(t *testing.T) {
-	result := renderers.BuildWorkflowPathReplacements("/ws", "skills")
+func TestBuildWorkflowPathReplacements_OnlyPathKeys(t *testing.T) {
+	result := renderers.BuildWorkflowPathReplacements(model.WorkflowManifest{}, "/ws", "skills")
 
-	if len(result) != 1 {
-		t.Errorf("expected exactly 1 replacement, got %d: %v", len(result), result)
+	if len(result) != 2 {
+		t.Errorf("expected exactly 2 replacements, got %d: %v", len(result), result)
 	}
 	got, ok := result["{SKILLS_PATH}"]
 	if !ok {
@@ -920,17 +920,19 @@ func TestBuildWorkflowPathReplacements_OnlySkillsPath(t *testing.T) {
 	if got != "/ws/skills" {
 		t.Errorf("{SKILLS_PATH} = %q, want %q", got, "/ws/skills")
 	}
-	// Verify no model placeholders are present.
-	for key := range result {
-		if key != "{SKILLS_PATH}" {
-			t.Errorf("unexpected key %q in result — only {SKILLS_PATH} should be present", key)
-		}
+	// WORKFLOW_DIR defaults to SKILLS_PATH when workingDir is empty.
+	gotWD, ok := result["{WORKFLOW_DIR}"]
+	if !ok {
+		t.Fatal("{WORKFLOW_DIR} key missing from result")
+	}
+	if gotWD != "/ws/skills" {
+		t.Errorf("{WORKFLOW_DIR} = %q, want %q (empty workingDir should yield skillsPath)", gotWD, "/ws/skills")
 	}
 }
 
 // TestBuildWorkflowPathReplacements_EmptySkillDir uses workspaceDir directly when skillDir is empty.
 func TestBuildWorkflowPathReplacements_EmptySkillDir(t *testing.T) {
-	result := renderers.BuildWorkflowPathReplacements("/ws", "")
+	result := renderers.BuildWorkflowPathReplacements(model.WorkflowManifest{}, "/ws", "")
 	got := result["{SKILLS_PATH}"]
 	if got != "/ws" {
 		t.Errorf("{SKILLS_PATH} = %q, want %q (empty skillDir should yield workspaceDir only)", got, "/ws")
@@ -940,7 +942,7 @@ func TestBuildWorkflowPathReplacements_EmptySkillDir(t *testing.T) {
 // TestBuildWorkflowPathReplacements_TrailingSlashStripped verifies trailing slashes are
 // stripped from both workspaceDir and skillDir before joining.
 func TestBuildWorkflowPathReplacements_TrailingSlashStripped(t *testing.T) {
-	result := renderers.BuildWorkflowPathReplacements("/ws/", "skills/")
+	result := renderers.BuildWorkflowPathReplacements(model.WorkflowManifest{}, "/ws/", "skills/")
 	got := result["{SKILLS_PATH}"]
 	const want = "/ws/skills"
 	if got != want {
@@ -952,12 +954,11 @@ func TestBuildWorkflowPathReplacements_TrailingSlashStripped(t *testing.T) {
 // buildWorkflowPlaceholderReplacements, this function never adds {SDD_MODEL_*} keys
 // regardless of the workflow manifest roles provided.
 func TestBuildWorkflowPathReplacements_NoModelKeysEvenWithRoles(t *testing.T) {
-	// The function doesn't take a WorkflowManifest — this test confirms the design
-	// by checking that no model keys appear when we use the path-only function.
-	result := renderers.BuildWorkflowPathReplacements("/project", "agents")
+	result := renderers.BuildWorkflowPathReplacements(model.WorkflowManifest{}, "/project", "agents")
+	allowedKeys := map[string]bool{"{SKILLS_PATH}": true, "{WORKFLOW_DIR}": true}
 	for key := range result {
-		if key != "{SKILLS_PATH}" {
-			t.Errorf("unexpected key %q — buildWorkflowPathReplacements must only produce {SKILLS_PATH}", key)
+		if !allowedKeys[key] {
+			t.Errorf("unexpected key %q — buildWorkflowPathReplacements must only produce path keys", key)
 		}
 	}
 }

--- a/internal/materialize/renderers/opencode.go
+++ b/internal/materialize/renderers/opencode.go
@@ -285,6 +285,10 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 	}
 
 	skillsBase := filepath.Join(workspaceRoot, r.def.SkillDir)
+	// OpenCode installs workflow files (orchestrator, _shared) in its own workspace
+	// to avoid conflicts with shared .agents/skills/ and to allow platform-specific
+	// placeholder resolution (subagent types = role names instead of "general").
+	workflowDir := filepath.Join(workspaceRoot, wf.Metadata.EffectiveWorkingDir())
 	if err := os.MkdirAll(skillsBase, 0o755); err != nil {
 		return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: workflow mkdir: %w", err)
 	}
@@ -331,9 +335,9 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 			continue
 		}
 
-		// Copy everything else (e.g. _shared/) as-is under skillsBase.
+		// Copy everything else (e.g. _shared/) as-is under workflowDir.
 		// agents/ and commands/ directories are NOT created — OpenCode uses opencode.json.
-		dstPath := filepath.Join(skillsBase, name)
+		dstPath := filepath.Join(workflowDir, name)
 		if err := copyEntry(srcPath, dstPath, entry); err != nil {
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: workflow copy %q: %w", name, err)
 		}
@@ -343,7 +347,13 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 	// Build shared placeholder replacements: {SKILLS_PATH} and {SDD_MODEL_*}.
 	// Uses buildWorkflowPlaceholderReplacements to avoid double-slash bugs and
 	// to ensure {SDD_MODEL_*} markers are resolved from workflow role metadata.
-	replacements := buildWorkflowPlaceholderReplacements(wf, workspaceRoot, r.def.SkillDir, resolveOpenCodeModel, r.modelOverrides)
+	// OpenCode subagent resolver: maps role names to their OpenCode agent names.
+	openCodeSubagentResolver := func(roleName string) string { return roleName }
+	replacements := buildWorkflowPlaceholderReplacements(wf, workspaceRoot, r.def.SkillDir, resolveOpenCodeModel, r.modelOverrides, openCodeSubagentResolver)
+	// Override {WORKFLOW_DIR} to point to the workspace-local workflow directory
+	// instead of the shared skillsBase path.
+	replacements["{WORKFLOW_DIR}"] = workflowDir
+
 
 	// Capture registry content for catalog injection; apply shared replacements.
 	if wf.Components.Registry != "" {
@@ -356,9 +366,15 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 		}
 	}
 
-	// Resolve placeholders in all installed .md files (covers {SKILLS_PATH} and {SDD_MODEL_*}).
+	// Resolve placeholders in skill .md files under skillsBase.
 	if err := resolvePlaceholders(skillsBase, replacements); err != nil {
-		return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: resolve placeholders: %w", err)
+		return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: resolve skill placeholders: %w", err)
+	}
+	// Resolve placeholders in workflow files under the workspace-local workflowDir (if it exists).
+	if _, statErr := os.Stat(workflowDir); statErr == nil {
+		if err := resolvePlaceholders(workflowDir, replacements); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: resolve workflow placeholders: %w", err)
+		}
 	}
 
 	// Synthesize SDD agents into opencode.json from components.roles.
@@ -464,7 +480,7 @@ func (r *OpenCodeRenderer) buildOrchestratorEntry(wf model.WorkflowManifest, rol
 		}
 	}
 
-	description := buildRoleDescription(role.Name, fmt.Sprintf("coordinates %s workflow via sub-agents", wf.Metadata.Name))
+	description := buildRoleDescription(role.Name, fmt.Sprintf("coordinates %s workflow via sub-agents", wf.Metadata.EffectiveDisplayName()))
 
 	entry := map[string]interface{}{
 		"description": description,

--- a/internal/materialize/renderers/opencode_test.go
+++ b/internal/materialize/renderers/opencode_test.go
@@ -409,7 +409,7 @@ components:
 func sddParityManifest() model.WorkflowManifest {
 	return model.WorkflowManifest{
 		APIVersion: "devrune/workflow/v1",
-		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0", WorkingDir: "sdd-orchestrator"},
 		Components: model.WorkflowComponents{
 			Skills:     []string{"sdd-plan"},
 			Entrypoint: "ORCHESTRATOR.md",
@@ -457,8 +457,8 @@ func TestOpenCodeRenderer_InstallWorkflow_SkillsUnderSkillsDir(t *testing.T) {
 		t.Errorf("expected %s to exist: %v", skillMD, err)
 	}
 
-	// POSITIVE: _shared/ directory installed under .agents/skills/
-	sharedDir := filepath.Join(agentsSkillsDir, "_shared")
+	// POSITIVE: _shared/ directory installed under .opencode/sdd-orchestrator/ (workspace-local, not shared)
+	sharedDir := filepath.Join(workspaceDir, "sdd-orchestrator", "_shared")
 	info, err := os.Stat(sharedDir)
 	if err != nil {
 		t.Errorf("expected %s to exist: %v", sharedDir, err)
@@ -694,7 +694,7 @@ components:
 
 	wf := model.WorkflowManifest{
 		APIVersion: "devrune/workflow/v1",
-		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0", WorkingDir: "sdd-orchestrator"},
 		Components: model.WorkflowComponents{
 			Skills:   []string{"sdd-plan"},
 			Registry: "REGISTRY.md",

--- a/internal/model/workflow.go
+++ b/internal/model/workflow.go
@@ -41,9 +41,26 @@ type WorkflowManifest struct {
 
 // WorkflowMetadata holds identifying information for a workflow.
 type WorkflowMetadata struct {
-	Name        string `yaml:"name"`                  // e.g. "sdd"
-	Description string `yaml:"description,omitempty"` // human-readable description
+	Name        string `yaml:"name"`                  // slug identifier, e.g. "sdd"
+	DisplayName string `yaml:"displayName,omitempty"` // human-readable label for catalogs, e.g. "SDD (Spec-Driven Development)"
 	Version     string `yaml:"version"`               // semver, e.g. "1.0.0"
+	WorkingDir  string `yaml:"workingDir,omitempty"`   // directory name for workflow files (orchestrator, _shared/); defaults to Name
+}
+
+// EffectiveDisplayName returns DisplayName if set, otherwise falls back to Name.
+func (m WorkflowMetadata) EffectiveDisplayName() string {
+	if m.DisplayName != "" {
+		return m.DisplayName
+	}
+	return m.Name
+}
+
+// EffectiveWorkingDir returns WorkingDir if set, otherwise falls back to Name.
+func (m WorkflowMetadata) EffectiveWorkingDir() string {
+	if m.WorkingDir != "" {
+		return m.WorkingDir
+	}
+	return m.Name
 }
 
 // WorkflowRole describes the projection metadata for a single agent role within a workflow.

--- a/testdata/workflows/invalid-no-name.yaml
+++ b/testdata/workflows/invalid-no-name.yaml
@@ -1,6 +1,6 @@
 apiVersion: devrune/workflow/v1
 metadata:
-  description: "Workflow missing a name"
+  displayName: "Workflow missing a name"
   version: "1.0.0"
 components:
   skills:

--- a/testdata/workflows/valid-no-entrypoint.yaml
+++ b/testdata/workflows/valid-no-entrypoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: devrune/workflow/v1
 metadata:
   name: simple-tools
-  description: "Simple tooling workflow without entrypoint"
+  displayName: "Simple Tooling"
   version: "0.2.0"
 components:
   skills:

--- a/testdata/workflows/valid-sdd.yaml
+++ b/testdata/workflows/valid-sdd.yaml
@@ -1,8 +1,9 @@
 apiVersion: devrune/workflow/v1
 metadata:
   name: sdd
-  description: "Spec-Driven Development workflow"
+  displayName: "SDD (Spec-Driven Development)"
   version: "1.0.0"
+  workingDir: sdd-orchestrator
 components:
   skills:
     - sdd-explore


### PR DESCRIPTION
## Summary
- Add `workingDir` and `displayName` to workflow metadata, remove `description`
- Introduce `{WORKFLOW_DIR}` placeholder for workflow file references (orchestrator, `_shared/`)
- Add `{WORKFLOW_SUBAGENT_*}` placeholders: Claude/factory/codex → `general`, OpenCode/copilot → role names
- OpenCode installs workflow files in own workspace (`.opencode/sdd-orchestrator/`) instead of shared `.agents/skills/`
- Generate CLAUDE.md and AGENTS.md independently — no symlink, each with correct agent-specific paths
- Fix `synthesizeAgents` skipped for opencode when `skillAlreadyRendered` (shared skillDir guard)
- Fix `init` command: wire TUI wizard for interactive mode
- Normalize paths with `filepath.Clean` to avoid `../` in resolved paths

## Test plan
- [x] All existing tests pass (clean run, 0 failures)
- [x] Verified installed layout for all 5 agents (claude, codex, opencode, copilot, factory)
- [x] CLAUDE.md has `.claude/` paths, AGENTS.md has `.agents/` paths
- [x] OpenCode subagent types resolve to role names in launch templates
- [x] Copilot subagent types resolve to role names in launch templates
- [x] opencode.json has agent section with 5 agents (was missing before)

> Requires companion PR in devrune-starter-catalog: davidarce/devrune-starter-catalog#new

🤖 Generated with [Claude Code](https://claude.com/claude-code)