### PR TITLE
feat(recommend): add skills.sh curated catalog integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,36 @@ When you choose AI Recommendations, DevRune:
 
 > The AI recommendation feature is optional — the wizard works exactly the same without it. If no AI agent is installed, only the "Confirm selection" button appears.
 
+## Skills.sh Curated Catalog
+
+DevRune integrates with [skills.sh](https://skills.sh) — the open agent skills directory — through a **curated static catalog** of audit-verified skills grouped by technology.
+
+When you run `devrune init`, the TUI wizard shows **Skills.sh Curated Catalog** as a selectable source alongside your other catalogs. If enabled, DevRune detects your project's tech stack (languages, frameworks, and dependencies) and surfaces only the skills that match.
+
+**How it works:**
+
+1. **Tech detection** — uses the same `detect.Analyze()` engine as AI Recommendations to scan your project (package.json, go.mod, pom.xml, build.gradle, etc.)
+2. **Static registry** — a compiled-in Go map of curated skills.sh skill paths, grouped by framework/language (React, Next.js, Spring Boot, Java, Go, Python, TypeScript, etc.)
+3. **Audit-verified** — every skill in the registry has been manually verified to pass security audits from all three skills.sh providers (Gen Agent Trust Hub, Socket, Snyk)
+4. **Zero network calls** — the registry is in-memory; actual skill content is fetched only during `devrune resolve` via the existing cached pipeline
+
+**In the TUI:**
+
+Skills appear in Step 3 under a "Skills.sh Curated" group with skills organized by detected technology. You can toggle individual skills on/off just like starter-catalog items.
+
+**Currently supported technologies:**
+
+| Frontend | Backend | Languages |
+|----------|---------|-----------|
+| React | Spring Boot | Java |
+| Next.js | Django | Kotlin |
+| Vue.js | FastAPI | Go |
+| Angular | Astro | Python |
+| Svelte | Remix | TypeScript |
+| Tailwind CSS | | |
+
+> The catalog is team-curated — adding a new technology or skill is a one-line addition to the static registry. All skills must pass the skills.sh security audit before being included.
+
 ## How It Works
 
 DevRune follows a **three-stage pipeline**:

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -135,7 +135,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	if !nonInteractive && !hasFlags {
 		// Interactive mode: launch TUI wizard with preselection from existing config (if any).
-		result, err := tui.Run(catalogSources, existing)
+		result, err := tui.Run(wd, catalogSources, existing)
 		if err != nil {
 			if errors.Is(err, huh.ErrUserAborted) {
 				_, _ = fmt.Fprintln(out, "Aborted.")

--- a/internal/cli/menu.go
+++ b/internal/cli/menu.go
@@ -305,7 +305,7 @@ func runInitFromMenu(cmd *cobra.Command) error {
 	}
 
 	// Run TUI wizard.
-	result, err := tui.Run(nil, nil)
+	result, err := tui.Run(wd, nil, nil)
 	if err != nil {
 		if err == huh.ErrUserAborted {
 			return nil

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -13,9 +13,16 @@ import (
 	"github.com/davidarce/devrune/internal/materialize"
 	"github.com/davidarce/devrune/internal/model"
 	"github.com/davidarce/devrune/internal/parse"
+	"github.com/davidarce/devrune/internal/recommend"
 	"github.com/davidarce/devrune/internal/resolve"
 	"github.com/davidarce/devrune/internal/state"
 )
+
+// skillsShCuratedSource is the sentinel Source value written into the manifest by
+// buildManifestFromSelection when the user selects skills from the Skills.sh
+// Curated catalog. RunResolve detects this sentinel and expands the entry into
+// proper github: PackageRefs before passing the manifest to the resolver.
+const skillsShCuratedSource = "Skills.sh Curated"
 
 // RunResolve executes the resolve pipeline: reads the manifest, fetches all
 // referenced packages, and writes devrune.lock. It returns the Lockfile on
@@ -44,6 +51,11 @@ func RunResolve(ctx context.Context, workDir string, manifestPath string, verbos
 	if err != nil {
 		return model.Lockfile{}, fmt.Errorf("parse manifest: %w", err)
 	}
+
+	// Expand any Skills.sh Curated sentinel entries into proper github: PackageRefs.
+	// These sentinels are written by buildManifestFromSelection when the user
+	// selects skills from the static skills.sh catalog in the TUI.
+	manifest.Packages = expandSkillsShPackages(manifest.Packages)
 
 	cacheDir := cachePath()
 	if verbose {
@@ -175,6 +187,53 @@ func extractWorkflowModels(manifest model.UserManifest) map[string]map[string]st
 		}
 	}
 	return merged
+}
+
+// expandSkillsShPackages scans the given PackageRef slice for entries with
+// Source == skillsShCuratedSource (the sentinel written by buildManifestFromSelection)
+// and replaces each such entry with the proper github: PackageRefs derived from
+// the selected skill names and the static SkillsRegistry.
+//
+// Each selected skill name (e.g. "vercel-react-best-practices") is looked up in
+// the registry to recover its full path (e.g. "vercel-labs/agent-skills/vercel-react-best-practices"),
+// then converted to a PackageRef via recommend.SkillRefToPackageRef. Skills that
+// cannot be found in the registry are silently skipped.
+//
+// PackageRefs without the sentinel source are returned unchanged.
+func expandSkillsShPackages(packages []model.PackageRef) []model.PackageRef {
+	// Build a reverse index: short skill name → SkillRef (with full path).
+	// The short name is the last path segment (same logic as skillName in select.go).
+	nameToRef := make(map[string]recommend.SkillRef)
+	for _, entry := range recommend.SkillsRegistry {
+		for _, ref := range entry.Skills {
+			short := recommend.SkillName(ref.Path)
+			nameToRef[short] = ref
+		}
+	}
+
+	result := make([]model.PackageRef, 0, len(packages))
+	for _, pkg := range packages {
+		if pkg.Source != skillsShCuratedSource {
+			result = append(result, pkg)
+			continue
+		}
+
+		// This is a Skills.sh Curated sentinel entry.
+		// Expand each selected skill name into its own PackageRef.
+		if pkg.Select == nil || len(pkg.Select.Skills) == 0 {
+			// Nothing selected — drop the sentinel entry.
+			continue
+		}
+		for _, skillShortName := range pkg.Select.Skills {
+			ref, ok := nameToRef[skillShortName]
+			if !ok {
+				// Unknown skill name — skip silently.
+				continue
+			}
+			result = append(result, recommend.SkillRefToPackageRef(ref))
+		}
+	}
+	return result
 }
 
 // countContents tallies skills and rules across all packages in a lockfile.

--- a/internal/cli/pipeline_test.go
+++ b/internal/cli/pipeline_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/davidarce/devrune/internal/model"
+)
+
+// ── expandSkillsShPackages ────────────────────────────────────────────────────
+
+func TestExpandSkillsShPackages_EmptyInput(t *testing.T) {
+	got := expandSkillsShPackages(nil)
+	if len(got) != 0 {
+		t.Errorf("expandSkillsShPackages(nil): want empty, got %d entries", len(got))
+	}
+
+	got = expandSkillsShPackages([]model.PackageRef{})
+	if len(got) != 0 {
+		t.Errorf("expandSkillsShPackages([]): want empty, got %d entries", len(got))
+	}
+}
+
+func TestExpandSkillsShPackages_NonSentinelPassedThrough(t *testing.T) {
+	packages := []model.PackageRef{
+		{Source: "github:owner/repo"},
+		{Source: "gitlab:other/pkg"},
+	}
+
+	got := expandSkillsShPackages(packages)
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[0].Source != "github:owner/repo" {
+		t.Errorf("got[0].Source: want %q, got %q", "github:owner/repo", got[0].Source)
+	}
+	if got[1].Source != "gitlab:other/pkg" {
+		t.Errorf("got[1].Source: want %q, got %q", "gitlab:other/pkg", got[1].Source)
+	}
+}
+
+func TestExpandSkillsShPackages_SentinelWithNoSelect(t *testing.T) {
+	packages := []model.PackageRef{
+		{Source: skillsShCuratedSource, Select: nil},
+	}
+
+	got := expandSkillsShPackages(packages)
+	// Sentinel with no select should be dropped entirely.
+	if len(got) != 0 {
+		t.Errorf("sentinel with nil select: want 0 entries, got %d", len(got))
+	}
+}
+
+func TestExpandSkillsShPackages_SentinelWithEmptySkills(t *testing.T) {
+	packages := []model.PackageRef{
+		{Source: skillsShCuratedSource, Select: &model.SelectFilter{Skills: []string{}}},
+	}
+
+	got := expandSkillsShPackages(packages)
+	if len(got) != 0 {
+		t.Errorf("sentinel with empty skills: want 0 entries, got %d", len(got))
+	}
+}
+
+func TestExpandSkillsShPackages_KnownSkillExpanded(t *testing.T) {
+	// "vercel-react-best-practices" is the short name of
+	// "vercel-labs/agent-skills/vercel-react-best-practices" in the registry.
+	packages := []model.PackageRef{
+		{
+			Source: skillsShCuratedSource,
+			Select: &model.SelectFilter{
+				Skills: []string{"vercel-react-best-practices"},
+			},
+		},
+	}
+
+	got := expandSkillsShPackages(packages)
+	if len(got) != 1 {
+		t.Fatalf("want 1 expanded PackageRef, got %d: %v", len(got), got)
+	}
+
+	// The expanded entry must reference the correct GitHub repo.
+	if got[0].Source != "github:vercel-labs/agent-skills" {
+		t.Errorf("Source: want %q, got %q", "github:vercel-labs/agent-skills", got[0].Source)
+	}
+
+	// The skill name must be preserved in the Select filter.
+	if got[0].Select == nil {
+		t.Fatal("Select: want non-nil, got nil")
+	}
+	if len(got[0].Select.Skills) != 1 || got[0].Select.Skills[0] != "vercel-react-best-practices" {
+		t.Errorf("Select.Skills: want [vercel-react-best-practices], got %v", got[0].Select.Skills)
+	}
+}
+
+func TestExpandSkillsShPackages_UnknownSkillSkipped(t *testing.T) {
+	packages := []model.PackageRef{
+		{
+			Source: skillsShCuratedSource,
+			Select: &model.SelectFilter{
+				Skills: []string{"this-skill-does-not-exist-in-registry"},
+			},
+		},
+	}
+
+	got := expandSkillsShPackages(packages)
+	if len(got) != 0 {
+		t.Errorf("unknown skill: want 0 entries, got %d", len(got))
+	}
+}
+
+func TestExpandSkillsShPackages_MultipleSkillsExpanded(t *testing.T) {
+	// Two known skills from the React entry in SkillsRegistry.
+	packages := []model.PackageRef{
+		{
+			Source: skillsShCuratedSource,
+			Select: &model.SelectFilter{
+				Skills: []string{
+					"vercel-react-best-practices",
+					"vercel-composition-patterns",
+				},
+			},
+		},
+	}
+
+	got := expandSkillsShPackages(packages)
+	if len(got) != 2 {
+		t.Fatalf("want 2 expanded PackageRefs, got %d", len(got))
+	}
+
+	sources := map[string]bool{}
+	for _, pkg := range got {
+		sources[pkg.Source] = true
+	}
+	if !sources["github:vercel-labs/agent-skills"] {
+		t.Error("want github:vercel-labs/agent-skills in expanded sources")
+	}
+}
+
+func TestExpandSkillsShPackages_MixedSentinelAndNormal(t *testing.T) {
+	packages := []model.PackageRef{
+		{Source: "github:some/other-pkg"},
+		{
+			Source: skillsShCuratedSource,
+			Select: &model.SelectFilter{
+				Skills: []string{"vercel-react-best-practices"},
+			},
+		},
+		{Source: "github:yet/another-pkg"},
+	}
+
+	got := expandSkillsShPackages(packages)
+	// 2 normal packages + 1 expanded sentinel skill = 3 total
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries, got %d: %v", len(got), got)
+	}
+	if got[0].Source != "github:some/other-pkg" {
+		t.Errorf("got[0].Source: want %q, got %q", "github:some/other-pkg", got[0].Source)
+	}
+	// got[1] is the expanded sentinel
+	if got[1].Source != "github:vercel-labs/agent-skills" {
+		t.Errorf("got[1].Source: want %q, got %q", "github:vercel-labs/agent-skills", got[1].Source)
+	}
+	if got[2].Source != "github:yet/another-pkg" {
+		t.Errorf("got[2].Source: want %q, got %q", "github:yet/another-pkg", got[2].Source)
+	}
+}

--- a/internal/recommend/skillssh_catalog.go
+++ b/internal/recommend/skillssh_catalog.go
@@ -29,10 +29,7 @@ func (c StaticCatalog) FetchByFrameworks(frameworks []string) ([]DetectedTech, e
 	var result []DetectedTech
 	for _, entry := range SkillsRegistry {
 		if _, ok := want[entry.Framework]; ok {
-			result = append(result, DetectedTech{
-				Framework: entry.Framework,
-				Skills:    entry.Skills,
-			})
+			result = append(result, DetectedTech(entry))
 		}
 	}
 	return result, nil
@@ -74,10 +71,7 @@ func (c StaticCatalog) FetchByProfile(profile *detect.ProjectProfile) ([]Detecte
 			continue
 		}
 		seen[entry.Framework] = struct{}{}
-		result = append(result, DetectedTech{
-			Framework: entry.Framework,
-			Skills:    entry.Skills,
-		})
+		result = append(result, DetectedTech(entry))
 	}
 	return result, nil
 }

--- a/internal/recommend/skillssh_catalog.go
+++ b/internal/recommend/skillssh_catalog.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+
+package recommend
+
+import (
+	"github.com/davidarce/devrune/internal/detect"
+)
+
+// StaticCatalog is the default implementation of CatalogFetcher.
+// It performs pure in-memory lookups against the package-level SkillsRegistry.
+// No network calls are made by StaticCatalog itself; skill content is fetched
+// only during `devrune resolve` via the existing cached MultiFetcher pipeline.
+type StaticCatalog struct{}
+
+// FetchByFrameworks returns DetectedTech entries for each framework name that
+// has a matching entry in SkillsRegistry. Frameworks with no registry entry are
+// silently ignored. The result preserves registry order for stable TUI display.
+func (c StaticCatalog) FetchByFrameworks(frameworks []string) ([]DetectedTech, error) {
+	if len(frameworks) == 0 {
+		return nil, nil
+	}
+
+	// Build a set for O(1) lookups.
+	want := make(map[string]struct{}, len(frameworks))
+	for _, f := range frameworks {
+		want[f] = struct{}{}
+	}
+
+	var result []DetectedTech
+	for _, entry := range SkillsRegistry {
+		if _, ok := want[entry.Framework]; ok {
+			result = append(result, DetectedTech{
+				Framework: entry.Framework,
+				Skills:    entry.Skills,
+			})
+		}
+	}
+	return result, nil
+}
+
+// FetchByProfile returns DetectedTech entries matching both the detected
+// frameworks and the detected languages in the given ProjectProfile.
+//
+// Framework entries are matched against profile.Frameworks; language entries
+// are matched against profile.Languages[].Name. Results are deduplicated so
+// that a registry entry matching both a framework name and a language name only
+// appears once. The combined result preserves registry order.
+func (c StaticCatalog) FetchByProfile(profile *detect.ProjectProfile) ([]DetectedTech, error) {
+	if profile == nil {
+		return nil, nil
+	}
+
+	// Collect all names to match: frameworks + languages.
+	names := make(map[string]struct{}, len(profile.Frameworks)+len(profile.Languages))
+	for _, f := range profile.Frameworks {
+		names[f] = struct{}{}
+	}
+	for _, l := range profile.Languages {
+		names[l.Name] = struct{}{}
+	}
+
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	// Walk registry in order; deduplicate via seen set.
+	seen := make(map[string]struct{})
+	var result []DetectedTech
+	for _, entry := range SkillsRegistry {
+		if _, ok := names[entry.Framework]; !ok {
+			continue
+		}
+		if _, already := seen[entry.Framework]; already {
+			continue
+		}
+		seen[entry.Framework] = struct{}{}
+		result = append(result, DetectedTech{
+			Framework: entry.Framework,
+			Skills:    entry.Skills,
+		})
+	}
+	return result, nil
+}
+
+// BuildSkillsCatalogItems converts a slice of DetectedTech values into
+// CatalogItem slices suitable for TUI display and AI recommendations.
+// Each SkillRef in each DetectedTech produces one CatalogItem with:
+//   - Name:        the last path segment of ref.Path (e.g. "vercel-react-best-practices")
+//   - Kind:        "skill"
+//   - Source:      the full ref.Path (e.g. "vercel-labs/agent-skills/vercel-react-best-practices")
+//   - Description: ref.Description
+func BuildSkillsCatalogItems(detected []DetectedTech) []CatalogItem {
+	var items []CatalogItem
+	for _, tech := range detected {
+		for _, ref := range tech.Skills {
+			items = append(items, CatalogItem{
+				Name:        SkillName(ref.Path),
+				Kind:        "skill",
+				Source:      ref.Path,
+				Description: ref.Description,
+			})
+		}
+	}
+	return items
+}
+
+// SkillName extracts the last path segment from a skills.sh path.
+// "vercel-labs/agent-skills/vercel-react-best-practices" → "vercel-react-best-practices"
+// "owner/repo" → "repo"
+func SkillName(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[i+1:]
+		}
+	}
+	return path
+}

--- a/internal/recommend/skillssh_catalog_test.go
+++ b/internal/recommend/skillssh_catalog_test.go
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: MIT
+
+package recommend
+
+import (
+	"testing"
+
+	"github.com/davidarce/devrune/internal/detect"
+)
+
+// ── T009: StaticCatalog.FetchByFrameworks and FetchByProfile ─────────────────
+
+func TestStaticCatalog_FetchByFrameworks(t *testing.T) {
+	catalog := StaticCatalog{}
+
+	t.Run("single known framework returns its skills", func(t *testing.T) {
+		got, err := catalog.FetchByFrameworks([]string{"React"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want 1 DetectedTech, got %d", len(got))
+		}
+		if got[0].Framework != "React" {
+			t.Errorf("want Framework=React, got %q", got[0].Framework)
+		}
+		if len(got[0].Skills) == 0 {
+			t.Error("want at least one skill for React, got none")
+		}
+	})
+
+	t.Run("multiple known frameworks returns skills for both", func(t *testing.T) {
+		got, err := catalog.FetchByFrameworks([]string{"React", "Spring Boot"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("want 2 DetectedTech entries, got %d", len(got))
+		}
+		frameworks := make(map[string]bool)
+		for _, dt := range got {
+			frameworks[dt.Framework] = true
+		}
+		if !frameworks["React"] {
+			t.Error("want React in result, not found")
+		}
+		if !frameworks["Spring Boot"] {
+			t.Error("want Spring Boot in result, not found")
+		}
+	})
+
+	t.Run("unknown framework returns empty slice with no error", func(t *testing.T) {
+		got, err := catalog.FetchByFrameworks([]string{"UnknownFramework"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("want empty slice, got %d entries", len(got))
+		}
+	})
+
+	t.Run("empty frameworks slice returns empty slice with no error", func(t *testing.T) {
+		got, err := catalog.FetchByFrameworks([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("want empty slice, got %d entries", len(got))
+		}
+	})
+
+	t.Run("mix of known and unknown frameworks returns only known", func(t *testing.T) {
+		got, err := catalog.FetchByFrameworks([]string{"React", "UnknownFramework"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want 1 DetectedTech, got %d", len(got))
+		}
+		if got[0].Framework != "React" {
+			t.Errorf("want Framework=React, got %q", got[0].Framework)
+		}
+	})
+
+	t.Run("results preserve registry order for stable TUI display", func(t *testing.T) {
+		// Vue.js appears before Angular in SkillsRegistry; verify ordering holds.
+		got, err := catalog.FetchByFrameworks([]string{"Angular", "Vue.js"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("want 2 DetectedTech entries, got %d", len(got))
+		}
+		if got[0].Framework != "Vue.js" {
+			t.Errorf("want Vue.js first (registry order), got %q first", got[0].Framework)
+		}
+		if got[1].Framework != "Angular" {
+			t.Errorf("want Angular second (registry order), got %q second", got[1].Framework)
+		}
+	})
+}
+
+func TestStaticCatalog_FetchByProfile(t *testing.T) {
+	catalog := StaticCatalog{}
+
+	t.Run("nil profile returns nil with no error", func(t *testing.T) {
+		got, err := catalog.FetchByProfile(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("want nil, got %v", got)
+		}
+	})
+
+	t.Run("empty profile returns nil with no error", func(t *testing.T) {
+		got, err := catalog.FetchByProfile(&detect.ProjectProfile{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("want nil, got %v", got)
+		}
+	})
+
+	t.Run("profile with React framework returns React skills", func(t *testing.T) {
+		profile := &detect.ProjectProfile{
+			Frameworks: []string{"React"},
+		}
+		got, err := catalog.FetchByProfile(profile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want 1 DetectedTech, got %d", len(got))
+		}
+		if got[0].Framework != "React" {
+			t.Errorf("want Framework=React, got %q", got[0].Framework)
+		}
+	})
+
+	t.Run("profile with Java language returns Java skills", func(t *testing.T) {
+		profile := &detect.ProjectProfile{
+			Languages: []detect.LanguageInfo{
+				{Name: "Java", Files: 10, Lines: 500, Percentage: 80},
+			},
+		}
+		got, err := catalog.FetchByProfile(profile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want 1 DetectedTech, got %d", len(got))
+		}
+		if got[0].Framework != "Java" {
+			t.Errorf("want Framework=Java, got %q", got[0].Framework)
+		}
+	})
+
+	t.Run("profile with React framework and Java language returns both", func(t *testing.T) {
+		profile := &detect.ProjectProfile{
+			Frameworks: []string{"React"},
+			Languages: []detect.LanguageInfo{
+				{Name: "Java", Files: 5, Lines: 200, Percentage: 30},
+			},
+		}
+		got, err := catalog.FetchByProfile(profile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("want 2 DetectedTech entries, got %d", len(got))
+		}
+		frameworks := make(map[string]bool)
+		for _, dt := range got {
+			frameworks[dt.Framework] = true
+		}
+		if !frameworks["React"] {
+			t.Error("want React in result, not found")
+		}
+		if !frameworks["Java"] {
+			t.Error("want Java in result, not found")
+		}
+	})
+
+	t.Run("profile with overlapping framework and language entry deduplicates", func(t *testing.T) {
+		// "Java" appears as both a language entry AND can appear as a framework
+		// if someone passes it in Frameworks. This test ensures no duplicate.
+		profile := &detect.ProjectProfile{
+			Frameworks: []string{"Java"},
+			Languages: []detect.LanguageInfo{
+				{Name: "Java", Files: 10, Lines: 500, Percentage: 90},
+			},
+		}
+		got, err := catalog.FetchByProfile(profile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Java must appear at most once even though it matches both criteria.
+		count := 0
+		for _, dt := range got {
+			if dt.Framework == "Java" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("want Java to appear exactly once (deduplication), got %d times", count)
+		}
+	})
+
+	t.Run("results preserve registry order for stable TUI display", func(t *testing.T) {
+		// In SkillsRegistry: React comes before Java.
+		// Profile has both, so React must appear first.
+		profile := &detect.ProjectProfile{
+			Frameworks: []string{"React"},
+			Languages: []detect.LanguageInfo{
+				{Name: "Java", Files: 5, Lines: 200, Percentage: 20},
+			},
+		}
+		got, err := catalog.FetchByProfile(profile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) < 2 {
+			t.Fatalf("want at least 2 entries, got %d", len(got))
+		}
+		if got[0].Framework != "React" {
+			t.Errorf("want React first (registry order), got %q", got[0].Framework)
+		}
+		if got[1].Framework != "Java" {
+			t.Errorf("want Java second (registry order), got %q", got[1].Framework)
+		}
+	})
+}
+
+// ── T010: BuildSkillsCatalogItems ─────────────────────────────────────────────
+
+func TestBuildSkillsCatalogItems(t *testing.T) {
+	t.Run("empty slice returns nil", func(t *testing.T) {
+		got := BuildSkillsCatalogItems(nil)
+		if got != nil {
+			t.Errorf("want nil, got %v", got)
+		}
+	})
+
+	t.Run("empty detected tech returns nil", func(t *testing.T) {
+		got := BuildSkillsCatalogItems([]DetectedTech{})
+		if got != nil {
+			t.Errorf("want nil, got %v", got)
+		}
+	})
+
+	t.Run("single tech with one skill produces one CatalogItem", func(t *testing.T) {
+		detected := []DetectedTech{
+			{
+				Framework: "React",
+				Skills: []SkillRef{
+					{
+						Path:        "vercel-labs/agent-skills/vercel-react-best-practices",
+						Description: "React best practices from Vercel",
+					},
+				},
+			},
+		}
+		got := BuildSkillsCatalogItems(detected)
+		if len(got) != 1 {
+			t.Fatalf("want 1 CatalogItem, got %d", len(got))
+		}
+		item := got[0]
+		if item.Name != "vercel-react-best-practices" {
+			t.Errorf("Name: want %q, got %q", "vercel-react-best-practices", item.Name)
+		}
+		if item.Kind != "skill" {
+			t.Errorf("Kind: want %q, got %q", "skill", item.Kind)
+		}
+		if item.Source != "vercel-labs/agent-skills/vercel-react-best-practices" {
+			t.Errorf("Source: want full path, got %q", item.Source)
+		}
+		if item.Description != "React best practices from Vercel" {
+			t.Errorf("Description: want %q, got %q", "React best practices from Vercel", item.Description)
+		}
+	})
+
+	t.Run("multiple techs produce items in order", func(t *testing.T) {
+		detected := []DetectedTech{
+			{
+				Framework: "React",
+				Skills: []SkillRef{
+					{Path: "vercel-labs/agent-skills/vercel-react-best-practices", Description: "React best practices"},
+					{Path: "vercel-labs/agent-skills/vercel-composition-patterns", Description: "Composition patterns"},
+				},
+			},
+			{
+				Framework: "Java",
+				Skills: []SkillRef{
+					{Path: "github/awesome-copilot/java-docs", Description: "Java docs"},
+				},
+			},
+		}
+		got := BuildSkillsCatalogItems(detected)
+		if len(got) != 3 {
+			t.Fatalf("want 3 CatalogItems, got %d", len(got))
+		}
+		// First two from React, last from Java.
+		if got[0].Name != "vercel-react-best-practices" {
+			t.Errorf("item[0].Name: want vercel-react-best-practices, got %q", got[0].Name)
+		}
+		if got[1].Name != "vercel-composition-patterns" {
+			t.Errorf("item[1].Name: want vercel-composition-patterns, got %q", got[1].Name)
+		}
+		if got[2].Name != "java-docs" {
+			t.Errorf("item[2].Name: want java-docs, got %q", got[2].Name)
+		}
+	})
+
+	t.Run("two-segment path uses repo name as skill name", func(t *testing.T) {
+		detected := []DetectedTech{
+			{
+				Framework: "Misc",
+				Skills: []SkillRef{
+					{Path: "owner/repo", Description: "no skill segment"},
+				},
+			},
+		}
+		got := BuildSkillsCatalogItems(detected)
+		if len(got) != 1 {
+			t.Fatalf("want 1 CatalogItem, got %d", len(got))
+		}
+		if got[0].Name != "repo" {
+			t.Errorf("Name: want %q, got %q", "repo", got[0].Name)
+		}
+		if got[0].Source != "owner/repo" {
+			t.Errorf("Source: want full path %q, got %q", "owner/repo", got[0].Source)
+		}
+	})
+
+	t.Run("all items have Kind=skill", func(t *testing.T) {
+		detected := []DetectedTech{
+			{
+				Framework: "React",
+				Skills: []SkillRef{
+					{Path: "a/b/c", Description: "desc1"},
+					{Path: "d/e/f", Description: "desc2"},
+				},
+			},
+		}
+		got := BuildSkillsCatalogItems(detected)
+		for i, item := range got {
+			if item.Kind != "skill" {
+				t.Errorf("item[%d].Kind: want %q, got %q", i, "skill", item.Kind)
+			}
+		}
+	})
+
+	t.Run("Description is propagated correctly", func(t *testing.T) {
+		desc := "A very specific description"
+		detected := []DetectedTech{
+			{
+				Framework: "SomeTech",
+				Skills: []SkillRef{
+					{Path: "x/y/z", Description: desc},
+				},
+			},
+		}
+		got := BuildSkillsCatalogItems(detected)
+		if len(got) != 1 {
+			t.Fatalf("want 1 item, got %d", len(got))
+		}
+		if got[0].Description != desc {
+			t.Errorf("Description: want %q, got %q", desc, got[0].Description)
+		}
+	})
+}

--- a/internal/recommend/skillssh_convert.go
+++ b/internal/recommend/skillssh_convert.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+
+package recommend
+
+import (
+	"strings"
+
+	"github.com/davidarce/devrune/internal/model"
+)
+
+// SkillRefToPackageRef converts a skills.sh SkillRef into a model.PackageRef
+// that the existing resolve pipeline can fetch.
+//
+// The skills.sh path format is "owner/repo/skill-name". This maps to:
+//   - Source: "github:owner/repo"
+//   - Select: model.SelectFilter{Skills: []string{"skill-name"}}
+//
+// Edge case: if the path has only two segments ("owner/repo"), the returned
+// PackageRef has no Select filter (fetches the entire repo).
+//
+// Paths with more than three segments treat the third and subsequent segments
+// joined with "/" as the skill name (handles nested skill paths gracefully).
+func SkillRefToPackageRef(ref SkillRef) model.PackageRef {
+	parts := strings.SplitN(ref.Path, "/", 3)
+
+	if len(parts) < 2 {
+		// Malformed path — return as-is with no select filter.
+		return model.PackageRef{
+			Source: "github:" + ref.Path,
+		}
+	}
+
+	source := "github:" + parts[0] + "/" + parts[1]
+
+	if len(parts) == 2 || parts[2] == "" {
+		// No skill name segment — fetch entire repo.
+		return model.PackageRef{
+			Source: source,
+		}
+	}
+
+	// Third segment (and beyond, already joined by SplitN) is the skill name.
+	skillName := parts[2]
+	return model.PackageRef{
+		Source: source,
+		Select: &model.SelectFilter{
+			Skills: []string{skillName},
+		},
+	}
+}

--- a/internal/recommend/skillssh_convert_test.go
+++ b/internal/recommend/skillssh_convert_test.go
@@ -90,6 +90,6 @@ func TestSkillRefToPackageRef_ReturnsCorrectType(t *testing.T) {
 	ref := SkillRef{Path: "owner/repo/skill", Description: "desc"}
 	got := SkillRefToPackageRef(ref)
 
-	// Verify the return type is model.PackageRef (compile-time check, also runtime)
-	var _ model.PackageRef = got
+	// Verify the return type is model.PackageRef (compile-time check).
+	_ = model.PackageRef(got)
 }

--- a/internal/recommend/skillssh_convert_test.go
+++ b/internal/recommend/skillssh_convert_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+
+package recommend
+
+import (
+	"testing"
+
+	"github.com/davidarce/devrune/internal/model"
+)
+
+func TestSkillRefToPackageRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantSrc  string
+		wantSkls []string // nil means no Select filter expected
+	}{
+		{
+			name:     "standard three-segment path",
+			path:     "owner/repo/skill-name",
+			wantSrc:  "github:owner/repo",
+			wantSkls: []string{"skill-name"},
+		},
+		{
+			name:     "vercel react best practices",
+			path:     "vercel-labs/agent-skills/vercel-react-best-practices",
+			wantSrc:  "github:vercel-labs/agent-skills",
+			wantSkls: []string{"vercel-react-best-practices"},
+		},
+		{
+			name:     "two-segment path — no skill name",
+			path:     "owner/repo",
+			wantSrc:  "github:owner/repo",
+			wantSkls: nil,
+		},
+		{
+			name:     "path with nested segments beyond three",
+			path:     "org/repo/nested/path",
+			wantSrc:  "github:org/repo",
+			wantSkls: []string{"nested/path"},
+		},
+		{
+			name:     "empty third segment treated as two-segment",
+			path:     "owner/repo/",
+			wantSrc:  "github:owner/repo",
+			wantSkls: nil,
+		},
+		{
+			name:     "single segment — malformed",
+			path:     "onlyone",
+			wantSrc:  "github:onlyone",
+			wantSkls: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ref := SkillRef{Path: tc.path, Description: "test"}
+			got := SkillRefToPackageRef(ref)
+
+			if got.Source != tc.wantSrc {
+				t.Errorf("Source: got %q, want %q", got.Source, tc.wantSrc)
+			}
+
+			if tc.wantSkls == nil {
+				if got.Select != nil && len(got.Select.Skills) > 0 {
+					t.Errorf("Select.Skills: expected none, got %v", got.Select.Skills)
+				}
+				return
+			}
+
+			if got.Select == nil {
+				t.Fatalf("Select: expected non-nil with skills %v, got nil", tc.wantSkls)
+			}
+
+			if len(got.Select.Skills) != len(tc.wantSkls) {
+				t.Fatalf("Select.Skills length: got %d, want %d", len(got.Select.Skills), len(tc.wantSkls))
+			}
+
+			for i, s := range tc.wantSkls {
+				if got.Select.Skills[i] != s {
+					t.Errorf("Select.Skills[%d]: got %q, want %q", i, got.Select.Skills[i], s)
+				}
+			}
+		})
+	}
+}
+
+func TestSkillRefToPackageRef_ReturnsCorrectType(t *testing.T) {
+	ref := SkillRef{Path: "owner/repo/skill", Description: "desc"}
+	got := SkillRefToPackageRef(ref)
+
+	// Verify the return type is model.PackageRef (compile-time check, also runtime)
+	var _ model.PackageRef = got
+}

--- a/internal/recommend/skillssh_registry.go
+++ b/internal/recommend/skillssh_registry.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+
+package recommend
+
+// SkillsRegistry is the static, team-curated catalog of skills.sh skill references,
+// grouped by framework or language name.
+//
+// Keys MUST match the exact strings returned by detect.inferFrameworks() for
+// framework-level entries (e.g., "React", "Next.js", "Spring Boot"), or the
+// LanguageInfo.Name field from detect.ProjectProfile.Languages for language-level
+// entries (e.g., "Java", "Kotlin", "Go", "Python", "TypeScript").
+//
+// All skills listed here have been manually verified to pass the skills.sh audit.
+// To add a new technology or skill, append an entry to this slice — no other
+// changes are required. The registry is a compiled-in Go data structure with
+// zero network calls; skill content is fetched only during `devrune resolve`.
+var SkillsRegistry = []FrameworkSkills{
+	// ── Frontend Frameworks ──────────────────────────────────────────────────
+	{
+		Framework: "React",
+		Skills: []SkillRef{
+			{
+				Path:        "vercel-labs/agent-skills/vercel-react-best-practices",
+				Description: "React best practices from Vercel",
+			},
+			{
+				Path:        "vercel-labs/agent-skills/vercel-composition-patterns",
+				Description: "Component composition patterns",
+			},
+		},
+	},
+	{
+		Framework: "Next.js",
+		Skills: []SkillRef{
+			{
+				Path:        "vercel-labs/next-skills/next-best-practices",
+				Description: "Next.js best practices and conventions",
+			},
+			{
+				Path:        "vercel-labs/next-skills/next-cache-components",
+				Description: "Caching and server components patterns",
+			},
+		},
+	},
+	{
+		Framework: "Vue.js",
+		Skills: []SkillRef{
+			{
+				Path:        "hyf0/vue-skills/vue-best-practices",
+				Description: "Vue.js best practices and conventions",
+			},
+		},
+	},
+	{
+		Framework: "Angular",
+		Skills: []SkillRef{
+			{
+				Path:        "angular/skills/angular-developer",
+				Description: "Angular development best practices",
+			},
+		},
+	},
+	{
+		Framework: "Svelte",
+		Skills: []SkillRef{
+			{
+				Path:        "sveltejs/ai-tools/svelte-core-bestpractices",
+				Description: "Svelte core best practices",
+			},
+		},
+	},
+	{
+		Framework: "Tailwind CSS",
+		Skills: []SkillRef{
+			{
+				Path:        "asyrafhussin/agent-skills/tailwind-best-practices",
+				Description: "Tailwind CSS best practices",
+			},
+		},
+	},
+	// ── Backend Frameworks ───────────────────────────────────────────────────
+	{
+		Framework: "Spring Boot",
+		Skills: []SkillRef{
+			{
+				Path:        "github/awesome-copilot/java-springboot",
+				Description: "Spring Boot patterns and conventions",
+			},
+		},
+	},
+	{
+		Framework: "Django",
+		Skills: []SkillRef{
+			{
+				Path:        "vintasoftware/django-ai-plugins/django-expert",
+				Description: "Django expert patterns and conventions",
+			},
+		},
+	},
+	{
+		Framework: "FastAPI",
+		Skills: []SkillRef{
+			{
+				Path:        "wshobson/agents/fastapi-templates",
+				Description: "FastAPI templates and best practices",
+			},
+		},
+	},
+	{
+		Framework: "Astro",
+		Skills: []SkillRef{
+			{
+				Path:        "astrolicious/agent-skills/astro",
+				Description: "Astro best practices and conventions",
+			},
+		},
+	},
+	{
+		Framework: "Remix",
+		Skills: []SkillRef{
+			{
+				Path:        "remix-run/agent-skills/react-router-framework-mode",
+				Description: "React Router framework mode (Remix)",
+			},
+		},
+	},
+	// ── Language-level entries ───────────────────────────────────────────────
+	// Matched via ProjectProfile.Languages[].Name rather than inferFrameworks().
+	{
+		Framework: "Java",
+		Skills: []SkillRef{
+			{
+				Path:        "github/awesome-copilot/java-docs",
+				Description: "Java documentation and reference patterns",
+			},
+			{
+				Path:        "affaan-m/everything-claude-code/java-coding-standards",
+				Description: "Java coding standards and patterns",
+			},
+		},
+	},
+	{
+		Framework: "Kotlin",
+		Skills: []SkillRef{
+			{
+				Path:        "github/awesome-copilot/kotlin-springboot",
+				Description: "Kotlin with Spring Boot patterns",
+			},
+			{
+				Path:        "affaan-m/everything-claude-code/kotlin-patterns",
+				Description: "Kotlin coding patterns and conventions",
+			},
+		},
+	},
+	{
+		Framework: "Go",
+		Skills: []SkillRef{
+			{
+				Path:        "affaan-m/everything-claude-code/golang-patterns",
+				Description: "Go patterns and idioms",
+			},
+		},
+	},
+	{
+		Framework: "Python",
+		Skills: []SkillRef{
+			{
+				Path:        "affaan-m/everything-claude-code/python-patterns",
+				Description: "Python patterns and conventions",
+			},
+		},
+	},
+	{
+		Framework: "TypeScript",
+		Skills: []SkillRef{
+			{
+				Path:        "wshobson/agents/typescript-advanced-types",
+				Description: "TypeScript advanced types and type safety",
+			},
+		},
+	},
+}

--- a/internal/recommend/skillssh_types.go
+++ b/internal/recommend/skillssh_types.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+package recommend
+
+// FrameworkSkills maps a framework name (as returned by detect.inferFrameworks)
+// to its curated skills.sh skill references.
+//
+// The Framework field must match the exact string returned by detect.inferFrameworks()
+// (e.g., "React", "Next.js", "Spring Boot").
+type FrameworkSkills struct {
+	Framework string     // must match detect.inferFrameworks() output, e.g. "React", "Next.js", "Spring Boot"
+	Skills    []SkillRef // curated skills for this framework
+}
+
+// SkillRef is a curated skill reference from skills.sh.
+// Path follows the format "owner/repo/skill-name".
+type SkillRef struct {
+	Path        string // skills.sh path: "owner/repo/skill-name"
+	Description string // short description for TUI display
+}
+
+// DetectedTech is the result of matching detected frameworks against the registry.
+type DetectedTech struct {
+	Framework string     // display name (matches FrameworkSkills.Framework)
+	Skills    []SkillRef // skills applicable for this framework
+}
+
+// CatalogFetcher provides skills grouped by technology.
+// StaticCatalog is the default implementation (embedded map).
+// Future implementations could call skills.sh API or other registries.
+type CatalogFetcher interface {
+	FetchByFrameworks(frameworks []string) ([]DetectedTech, error)
+}

--- a/internal/resolve/enumerator.go
+++ b/internal/resolve/enumerator.go
@@ -239,6 +239,9 @@ func normalizeAppliesToValue(v interface{}) string {
 // Matching rules:
 //   - A skill is included if its Name appears in filter.Skills (or filter.Skills is empty).
 //   - A rule is included if its Name appears in filter.Rules (or filter.Rules is empty).
+//   - When one kind has explicit selections and the other is empty, the empty kind
+//     is excluded (not "include all"). This prevents a skills-only filter from
+//     accidentally pulling in all rules from a large repo.
 //   - Prompts are always included (not filterable in MVP).
 func ApplyFilter(items []model.ContentItem, filter *model.SelectFilter) []model.ContentItem {
 	if filter == nil {
@@ -248,15 +251,27 @@ func ApplyFilter(items []model.ContentItem, filter *model.SelectFilter) []model.
 	skillSet := toSet(filter.Skills)
 	ruleSet := toSet(filter.Rules)
 
+	// When one kind has explicit selections and the other is empty,
+	// treat the empty kind as "exclude all" rather than "include all".
+	hasExplicitSkills := len(skillSet) > 0
+	hasExplicitRules := len(ruleSet) > 0
+
 	result := make([]model.ContentItem, 0, len(items))
 	for _, item := range items {
 		switch item.Kind {
 		case model.KindSkill:
-			if len(skillSet) == 0 || skillSet[item.Name] {
+			if !hasExplicitSkills || skillSet[item.Name] {
 				result = append(result, item)
 			}
 		case model.KindRule:
-			if len(ruleSet) == 0 || ruleSet[item.Name] {
+			if !hasExplicitRules {
+				// If no explicit rule selection and no explicit skill selection either,
+				// include all rules (backwards-compatible: nil-like filter).
+				// But if skills are explicitly selected, exclude unselected rules.
+				if !hasExplicitSkills {
+					result = append(result, item)
+				}
+			} else if ruleSet[item.Name] {
 				result = append(result, item)
 			}
 		default:

--- a/internal/resolve/enumerator_test.go
+++ b/internal/resolve/enumerator_test.go
@@ -243,9 +243,10 @@ func TestApplyFilter_SkillSelection(t *testing.T) {
 
 	result := ApplyFilter(items, filter)
 
-	// Should have git-commit + sdd-explore (skills) + architecture/clean (rule, unfiltered since no rules filter)
-	if len(result) != 3 {
-		t.Errorf("got %d items, want 3; items = %v", len(result), result)
+	// Should have git-commit + sdd-explore (skills only). Rules are excluded
+	// when skills are explicitly selected but rules are not.
+	if len(result) != 2 {
+		t.Errorf("got %d items, want 2; items = %v", len(result), result)
 	}
 
 	skillNames := contentNames(itemsByKind(result, model.KindSkill))

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -231,15 +231,20 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 		}
 
 		if len(inputs) > 0 {
+			// Detect whether an AI agent (claude/opencode) is available on PATH.
+			// This is fast (exec.LookPath) and safe to call before the select loop.
+			_, _, agentDetectErr := recommend.DetectAgent()
+			agentAvailable := agentDetectErr == nil
+
 			// Loop: select → (optional) AI recommendations → back to select if user declines.
 			var prevSelection *steps.SelectionResult // preserves state on go-back
 			for {
 				var selectResult steps.SelectModelResult
 				var err error
 				if prevSelection != nil {
-					selectResult, err = steps.RunSelectModel(inputs, recommendEnabled, projectDir, *prevSelection)
+					selectResult, err = steps.RunSelectModel(inputs, recommendEnabled, agentAvailable, projectDir, *prevSelection)
 				} else {
-					selectResult, err = steps.RunSelectModel(inputs, recommendEnabled, projectDir)
+					selectResult, err = steps.RunSelectModel(inputs, recommendEnabled, agentAvailable, projectDir)
 				}
 				if err != nil {
 					return RunResult{}, mapErr(err)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -11,7 +11,9 @@ import (
 	"charm.land/huh/v2"
 	"gopkg.in/yaml.v3"
 
+	"github.com/davidarce/devrune/internal/detect"
 	"github.com/davidarce/devrune/internal/model"
+	"github.com/davidarce/devrune/internal/recommend"
 	"github.com/davidarce/devrune/internal/tui/steps"
 )
 
@@ -50,6 +52,10 @@ type ExistingConfig struct {
 //	Step 3: Scan + category/item selection
 //	Step 4: Summary + confirmation
 //
+// projectDir is the root directory of the project being configured. It is passed
+// to RunSelectModel for tech-stack detection and skills.sh curated skill injection.
+// Pass an empty string to skip detection.
+//
 // catalogSources contains source ref strings from the catalogs: key in devrune.yaml
 // or from --catalog CLI flags. They appear as pre-selected options
 // alongside the built-in known sources in Step 2. Pass nil or an empty slice when
@@ -61,7 +67,7 @@ type ExistingConfig struct {
 //
 // If the user aborts at any step (Ctrl-C or declining confirmation) the
 // function returns huh.ErrUserAborted.
-func Run(catalogSources []string, existing *ExistingConfig) (RunResult, error) {
+func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (RunResult, error) {
 	// Determine preselected agents and sources from existing config.
 	var preselectedAgents []string
 	var preselectedSources []string
@@ -114,36 +120,84 @@ func Run(catalogSources []string, existing *ExistingConfig) (RunResult, error) {
 	var scanned []steps.ScanResult
 	var inputs []steps.ScannedRepoInput
 
-	if len(sources) > 0 {
+	// Separate the skills.sh sentinel from real repo sources before scanning.
+	skillsShEnabled := false
+	realSources := make([]string, 0, len(sources))
+	for _, s := range sources {
+		if s == steps.SkillsShCuratedValue {
+			skillsShEnabled = true
+		} else {
+			realSources = append(realSources, s)
+		}
+	}
+
+	if len(realSources) > 0 || skillsShEnabled {
 		cp := cachePath()
 
-		// Wrap ScanRepositories so the steps package can call it without
-		// importing the tui package (avoids import cycle).
+		// skillsShInput captures the skills.sh ScannedRepoInput built inside
+		// the scan function (which runs under the spinner alt-screen).
+		var skillsShInput *steps.ScannedRepoInput
+
+		// The scan function runs inside the bubbletea alt-screen spinner.
+		// It scans real repos AND detects the tech stack for skills.sh — all
+		// under the same spinner so the user never sees a blank terminal.
 		scanFn := func(ctx context.Context, srcs []string, cachePath string) ([]steps.ScanResult, error) {
-			s, err := ScanRepositories(ctx, srcs, cachePath)
-			if err != nil {
-				return nil, err
-			}
-			out := make([]steps.ScanResult, len(s))
-			for i, r := range s {
-				out[i] = steps.ScanResult{
-					Source:            r.Source,
-					Skills:            r.Skills,
-					Rules:             r.Rules,
-					MCPs:              r.MCPs,
-					Workflows:         r.Workflows,
-					WorkflowManifests: r.WorkflowManifests,
-					Descs:             r.Descs,
-					MCPFiles:          r.MCPFiles,
-					Tools:             r.Tools,
-					Error:             r.Error,
+			var repoResults []steps.ScanResult
+
+			// Scan real repos (skip the skills.sh display entry).
+			realSrcs := make([]string, 0, len(srcs))
+			for _, s := range srcs {
+				if s != "Skills.sh Curated" {
+					realSrcs = append(realSrcs, s)
 				}
 			}
-			return out, nil
+
+			if len(realSrcs) > 0 {
+				s, scanErr := ScanRepositories(ctx, realSrcs, cachePath)
+				if scanErr != nil {
+					return nil, scanErr
+				}
+				repoResults = make([]steps.ScanResult, len(s))
+				for i, r := range s {
+					repoResults[i] = steps.ScanResult{
+						Source:            r.Source,
+						Skills:            r.Skills,
+						Rules:             r.Rules,
+						MCPs:              r.MCPs,
+						Workflows:         r.Workflows,
+						WorkflowManifests: r.WorkflowManifests,
+						Descs:             r.Descs,
+						MCPFiles:          r.MCPFiles,
+						Tools:             r.Tools,
+						Error:             r.Error,
+					}
+				}
+			}
+
+			// Detect tech stack for skills.sh (runs inside the spinner).
+			// The result is captured via closure — it needs SkillHeaders which
+			// ScanResult cannot carry.
+			if skillsShEnabled && projectDir != "" {
+				if profile, detectErr := detect.Analyze(projectDir); detectErr == nil {
+					catalog := recommend.StaticCatalog{}
+					if detected, fetchErr := catalog.FetchByProfile(profile); fetchErr == nil {
+						skillsShInput = steps.BuildSkillsShInput(detected)
+					}
+				}
+			}
+
+			return repoResults, nil
+		}
+
+		// Build the list of sources to show in the spinner.
+		scanSources := make([]string, len(realSources))
+		copy(scanSources, realSources)
+		if skillsShEnabled {
+			scanSources = append(scanSources, "Skills.sh Curated")
 		}
 
 		var warnings []string
-		scanned, warnings, err = steps.RunScanModel(sources, scanFn, cp)
+		scanned, warnings, err = steps.RunScanModel(scanSources, scanFn, cp)
 		if err != nil {
 			return RunResult{}, fmt.Errorf("scan repositories: %w", err)
 		}
@@ -171,6 +225,11 @@ func Run(catalogSources []string, existing *ExistingConfig) (RunResult, error) {
 			}
 		}
 
+		// Append skills.sh input (with SkillHeaders preserved).
+		if skillsShInput != nil {
+			inputs = append(inputs, *skillsShInput)
+		}
+
 		if len(inputs) > 0 {
 			// Loop: select → (optional) AI recommendations → back to select if user declines.
 			var prevSelection *steps.SelectionResult // preserves state on go-back
@@ -178,9 +237,9 @@ func Run(catalogSources []string, existing *ExistingConfig) (RunResult, error) {
 				var selectResult steps.SelectModelResult
 				var err error
 				if prevSelection != nil {
-					selectResult, err = steps.RunSelectModel(inputs, recommendEnabled, *prevSelection)
+					selectResult, err = steps.RunSelectModel(inputs, recommendEnabled, projectDir, *prevSelection)
 				} else {
-					selectResult, err = steps.RunSelectModel(inputs, recommendEnabled)
+					selectResult, err = steps.RunSelectModel(inputs, recommendEnabled, projectDir)
 				}
 				if err != nil {
 					return RunResult{}, mapErr(err)

--- a/internal/tui/recommend_bg.go
+++ b/internal/tui/recommend_bg.go
@@ -80,11 +80,22 @@ func (r *RecommendRunner) Start(ctx context.Context, dir string) {
 		}
 
 		// Step 4: Convert scanned repos to catalog items.
+		// Filter out skill headers (non-interactive labels like "Go")
+		// so the AI doesn't recommend them as installable skills.
 		sources := make([]recommend.ScannedSource, 0, len(repos))
 		for _, repo := range repos {
+			skills := repo.Skills
+			if len(repo.SkillHeaders) > 0 {
+				skills = make([]string, 0, len(repo.Skills))
+				for _, s := range repo.Skills {
+					if !repo.SkillHeaders[s] {
+						skills = append(skills, s)
+					}
+				}
+			}
 			sources = append(sources, recommend.ScannedSource{
 				Source:    repo.Source,
-				Skills:    repo.Skills,
+				Skills:    skills,
 				Rules:     repo.Rules,
 				MCPs:      repo.MCPs,
 				Workflows: repo.Workflows,

--- a/internal/tui/scanner.go
+++ b/internal/tui/scanner.go
@@ -68,7 +68,14 @@ func ScanRepositories(ctx context.Context, sources []string, cp string) ([]Scann
 			continue
 		}
 
-		items, err := resolve.EnumerateContents(dir)
+		// If the source ref has a subpath (e.g. //frontend), scan inside
+		// that subdirectory rather than the repo root.
+		scanDir := dir
+		if sourceRef.Subpath != "" {
+			scanDir = filepath.Join(dir, sourceRef.Subpath)
+		}
+
+		items, err := resolve.EnumerateContents(scanDir)
 		if err != nil {
 			repo.Error = fmt.Errorf("enumerate: %w", err)
 			results = append(results, repo)
@@ -80,7 +87,7 @@ func ScanRepositories(ctx context.Context, sources []string, cp string) ([]Scann
 			case model.KindSkill:
 				repo.Skills = append(repo.Skills, item.Name)
 				// Extract description from SKILL.md frontmatter.
-				if desc := readFrontmatterDesc(filepath.Join(dir, item.Path, "SKILL.md")); desc != "" {
+				if desc := readFrontmatterDesc(filepath.Join(scanDir, item.Path, "SKILL.md")); desc != "" {
 					repo.Descs[item.Name] = desc
 				}
 			case model.KindRule:
@@ -89,17 +96,17 @@ func ScanRepositories(ctx context.Context, sources []string, cp string) ([]Scann
 		}
 
 		// Discover MCPs: files in mcps/ directory.
-		repo.MCPs, repo.MCPFiles = discoverMCPs(dir)
+		repo.MCPs, repo.MCPFiles = discoverMCPs(scanDir)
 
 		// Discover workflows: subdirectories containing workflow.yaml.
-		repo.Workflows = discoverWorkflows(dir)
+		repo.Workflows = discoverWorkflows(scanDir)
 
 		// Discover tools: YAML files in tools/ directory.
-		repo.Tools = discoverTools(dir)
+		repo.Tools = discoverTools(scanDir)
 
 		// Parse workflow manifests and read descriptions.
 		for _, wf := range repo.Workflows {
-			wfPath := filepath.Join(dir, "workflows", wf, "workflow.yaml")
+			wfPath := filepath.Join(scanDir, "workflows", wf, "workflow.yaml")
 			if desc := readWorkflowDesc(wfPath); desc != "" {
 				repo.Descs[wf] = desc
 			}

--- a/internal/tui/steps/agents.go
+++ b/internal/tui/steps/agents.go
@@ -52,6 +52,8 @@ func SelectAgents(preselected []string) ([]string, error) {
 					return nil
 				}).
 				Value(&selected),
+			huh.NewNote().
+				Description(tuistyles.StyleHighlight.Render("⚠️  Selecting more than 1 agent may cause conflicts in instructions and workflows.")),
 		),
 	).WithTheme(tuistyles.DevRuneThemeFunc).
 		WithViewHook(func(v tea.View) tea.View {

--- a/internal/tui/steps/confirm.go
+++ b/internal/tui/steps/confirm.go
@@ -149,37 +149,46 @@ func buildManifestFromSelection(agents []string, selection SelectionResult, work
 			continue
 		}
 
+		validScheme := hasValidSourceScheme(repo.Source)
+
 		// Build SelectFilter only if not all items are selected.
 		// For simplicity in MVP, always include a SelectFilter with chosen items.
 		// A nil filter means "all items"; explicit lists mean "only these".
-		var sel *model.SelectFilter
+		// Skills.sh Curated repos use a sentinel source that is expanded later
+		// in the pipeline (expandSkillsShPackages), so they are included here.
 		if len(repo.SelectedSkills) > 0 || len(repo.SelectedRules) > 0 {
+			var sel *model.SelectFilter
 			sel = &model.SelectFilter{
 				Skills: repo.SelectedSkills,
 				Rules:  repo.SelectedRules,
 			}
+			pkgRefs = append(pkgRefs, model.PackageRef{
+				Source: repo.Source,
+				Select: sel,
+			})
+		} else if validScheme {
+			pkgRefs = append(pkgRefs, model.PackageRef{
+				Source: repo.Source,
+			})
 		}
 
-		pkgRefs = append(pkgRefs, model.PackageRef{
-			Source: repo.Source,
-			Select: sel,
-		})
-
-		// MCPs from this repo become separate MCPRef entries.
-		for _, mcp := range repo.SelectedMCPs {
-			mcpSrc := buildMCPSourceRef(repo.Source, mcp, repo.MCPFiles)
-			mcpRefs = append(mcpRefs, model.MCPRef{Source: mcpSrc})
-		}
-
-		// Workflows from this repo become WorkflowEntry values in the map.
-		// The workflow model overrides (workflowModels) are attached to every workflow entry.
-		for _, wf := range repo.SelectedWorkflows {
-			wfSrc := appendSubpath(repo.Source, "workflows/"+wf)
-			entry := model.WorkflowEntry{Source: wfSrc}
-			if len(workflowModels) > 0 {
-				entry.Roles = workflowModels
+		// MCPs and workflows require a valid scheme to form source refs.
+		// Repos without a valid scheme (e.g. "Skills.sh Curated") are skipped
+		// for MCPs/workflows since appendSubpath would produce invalid refs.
+		if validScheme {
+			for _, mcp := range repo.SelectedMCPs {
+				mcpSrc := buildMCPSourceRef(repo.Source, mcp, repo.MCPFiles)
+				mcpRefs = append(mcpRefs, model.MCPRef{Source: mcpSrc})
 			}
-			workflowEntries[wf] = entry
+
+			for _, wf := range repo.SelectedWorkflows {
+				wfSrc := appendSubpath(repo.Source, "workflows/"+wf)
+				entry := model.WorkflowEntry{Source: wfSrc}
+				if len(workflowModels) > 0 {
+					entry.Roles = workflowModels
+				}
+				workflowEntries[wf] = entry
+			}
 		}
 	}
 
@@ -197,6 +206,7 @@ func buildManifestFromSelection(agents []string, selection SelectionResult, work
 		Catalogs:      catalogSources,
 	}
 }
+
 
 // appendSubpath appends a subpath to a source ref string.
 // For remote sources (github/gitlab), it uses the "//" separator convention.

--- a/internal/tui/steps/confirm.go
+++ b/internal/tui/steps/confirm.go
@@ -157,8 +157,7 @@ func buildManifestFromSelection(agents []string, selection SelectionResult, work
 		// Skills.sh Curated repos use a sentinel source that is expanded later
 		// in the pipeline (expandSkillsShPackages), so they are included here.
 		if len(repo.SelectedSkills) > 0 || len(repo.SelectedRules) > 0 {
-			var sel *model.SelectFilter
-			sel = &model.SelectFilter{
+			sel := &model.SelectFilter{
 				Skills: repo.SelectedSkills,
 				Rules:  repo.SelectedRules,
 			}

--- a/internal/tui/steps/recommend.go
+++ b/internal/tui/steps/recommend.go
@@ -169,7 +169,8 @@ func MergeRecommendationsIntoSelection(prev SelectionResult, recs []recommend.Re
 		}
 	}
 
-	// For each repo, add recommended items not already selected.
+	// For each recommendation, add it to the repo whose source matches.
+	// Each recommendation carries a Source field identifying which repo it belongs to.
 	for ri := range merged.Repos {
 		repo := &merged.Repos[ri]
 
@@ -191,7 +192,7 @@ func MergeRecommendationsIntoSelection(prev SelectionResult, recs []recommend.Re
 				existing[item] = true
 			}
 			for _, rec := range recs {
-				if rec.Kind == lr.kind && rec.Confidence >= threshold && !existing[rec.Name] {
+				if rec.Kind == lr.kind && rec.Source == repo.Source && rec.Confidence >= threshold && !existing[rec.Name] {
 					*lr.list = append(*lr.list, rec.Name)
 					existing[rec.Name] = true
 				}
@@ -200,6 +201,36 @@ func MergeRecommendationsIntoSelection(prev SelectionResult, recs []recommend.Re
 	}
 
 	return merged
+}
+
+// reposToSources converts ScannedRepoInput slices to ScannedSource slices,
+// filtering out skill headers (non-interactive labels like "Go", "Spring Boot")
+// so the AI doesn't recommend them as installable skills.
+func reposToSources(repos []ScannedRepoInput) []recommend.ScannedSource {
+	sources := make([]recommend.ScannedSource, 0, len(repos))
+	for _, r := range repos {
+		skills := r.Skills
+		if len(r.SkillHeaders) > 0 {
+			skills = make([]string, 0, len(r.Skills))
+			for _, s := range r.Skills {
+				if !r.SkillHeaders[s] {
+					skills = append(skills, s)
+				}
+			}
+		}
+		sources = append(sources, recommend.ScannedSource{
+			Source: r.Source, Skills: skills, Rules: r.Rules,
+			MCPs: r.MCPs, Workflows: r.Workflows, Descs: r.Descs,
+		})
+	}
+	return sources
+}
+
+// hasValidSourceScheme checks if a repo source has a recognized scheme prefix.
+func hasValidSourceScheme(source string) bool {
+	return strings.HasPrefix(source, "github:") ||
+		strings.HasPrefix(source, "gitlab:") ||
+		strings.HasPrefix(source, "local:")
 }
 
 // RunRecommendStep shows the gate. Accept → merge recommendations into selection.
@@ -294,13 +325,7 @@ func (m recommendFlowModel) doRecommend() tea.Cmd {
 			return recommendFlowDoneMsg{err: err}
 		}
 
-		sources := make([]recommend.ScannedSource, 0, len(repos))
-		for _, r := range repos {
-			sources = append(sources, recommend.ScannedSource{
-				Source: r.Source, Skills: r.Skills, Rules: r.Rules,
-				MCPs: r.MCPs, Workflows: r.Workflows, Descs: r.Descs,
-			})
-		}
+		sources := reposToSources(repos)
 		catalog := recommend.BuildCatalogItems(sources)
 
 		cfg := recommend.RecommendConfig{Threshold: 0.7, Enabled: true, Models: recommend.DefaultAgentModels()}
@@ -434,13 +459,7 @@ type RecommendFlowResult struct {
 func RunRecommendFlow(repos []ScannedRepoInput) RecommendFlowResult {
 	// Quick cache check.
 	dir, _ := os.Getwd()
-	sources := make([]recommend.ScannedSource, 0, len(repos))
-	for _, r := range repos {
-		sources = append(sources, recommend.ScannedSource{
-			Source: r.Source, Skills: r.Skills, Rules: r.Rules,
-			MCPs: r.MCPs, Workflows: r.Workflows, Descs: r.Descs,
-		})
-	}
+	sources := reposToSources(repos)
 	catalog := recommend.BuildCatalogItems(sources)
 	cached := recommend.CheckQuickCache(dir, catalog, 0.7)
 

--- a/internal/tui/steps/recommend_test.go
+++ b/internal/tui/steps/recommend_test.go
@@ -28,8 +28,8 @@ func TestMerge_AddsRecommendedItems(t *testing.T) {
 	prev := makePrevSelection([]string{"git-commit"}, nil)
 
 	recs := []recommend.Recommendation{
-		{Name: "architect-adviser", Kind: "skill", Confidence: 0.92},
-		{Name: "unit-test-adviser", Kind: "skill", Confidence: 0.85},
+		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
+		{Name: "unit-test-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.85},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0.7)
@@ -55,7 +55,7 @@ func TestMerge_BelowThresholdNotAdded(t *testing.T) {
 	prev := makePrevSelection(nil, nil)
 
 	recs := []recommend.Recommendation{
-		{Name: "architect-adviser", Kind: "skill", Confidence: 0.45},
+		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.45},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0.7)
@@ -70,7 +70,7 @@ func TestMerge_NoDuplicates(t *testing.T) {
 	prev := makePrevSelection([]string{"architect-adviser"}, nil)
 
 	recs := []recommend.Recommendation{
-		{Name: "architect-adviser", Kind: "skill", Confidence: 0.92},
+		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0.7)
@@ -85,7 +85,7 @@ func TestMerge_PreservesOriginalSelection(t *testing.T) {
 	prev := makePrevSelection([]string{"git-commit"}, []string{"clean-architecture"})
 
 	recs := []recommend.Recommendation{
-		{Name: "architect-adviser", Kind: "skill", Confidence: 0.92},
+		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0.7)
@@ -120,8 +120,8 @@ func TestMerge_DefaultThreshold(t *testing.T) {
 	prev := makePrevSelection(nil, nil)
 
 	recs := []recommend.Recommendation{
-		{Name: "above", Kind: "skill", Confidence: 0.92},
-		{Name: "below", Kind: "skill", Confidence: 0.5},
+		{Name: "above", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
+		{Name: "below", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.5},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0)

--- a/internal/tui/steps/repos.go
+++ b/internal/tui/steps/repos.go
@@ -18,9 +18,16 @@ type knownSource struct {
 	value string // raw source ref string (e.g. "github:owner/repo")
 }
 
+// SkillsShCuratedValue is the sentinel value used to identify the Skills.sh
+// Curated Catalog in the repository source selection. It is not a real git
+// source ref — the TUI select step intercepts it and injects the static
+// skills registry instead of scanning a remote repository.
+const SkillsShCuratedValue = "skillssh:curated"
+
 // knownSources lists predefined repository catalog sources.
 var knownSources = []knownSource{
 	{label: "DevRune Starter Catalog", value: "github:davidarce/devrune-starter-catalog"},
+	{label: "Skills.sh Curated Catalog", value: SkillsShCuratedValue},
 }
 
 // EnterRepositories presents predefined repository catalog sources for selection,

--- a/internal/tui/steps/select.go
+++ b/internal/tui/steps/select.go
@@ -115,13 +115,31 @@ type SelectModel struct {
 
 	// Recommendation support.
 	recEnabled         bool // show the "Confirm with AI recommendations" button
+	recDisabled        bool // true when rec button is visible but not interactive (no agent on PATH)
 	useRecommendations bool // true if user chose "Confirm with AI recommendations"
+
+	// Validation.
+	errorMsg string // non-empty when a validation error should be shown
+}
+
+// totalSelectedCount returns the total number of selected items across all repos and categories.
+// Header items are excluded from the count.
+func (m *SelectModel) totalSelectedCount() int {
+	total := 0
+	for ri := range m.repos {
+		for ci := range m.repos[ri].Categories {
+			total += m.repos[ri].Categories[ci].selectedCount()
+		}
+	}
+	return total
 }
 
 // flatLen returns the total number of navigable rows (categories + confirm buttons).
+// When the rec button is disabled (recDisabled), it is visible but not navigable,
+// so it is excluded from the flat length.
 func (m *SelectModel) flatLen() int {
 	buttons := 1
-	if m.recEnabled {
+	if m.recEnabled && !m.recDisabled {
 		buttons = 2
 	}
 	return len(m.repos)*5 + buttons
@@ -179,6 +197,32 @@ func NewSelectModel(repos []ScannedRepoInput) *SelectModel {
 			buildCategoryWithDescs("Workflows", r.Workflows, descs),
 			buildCategoryWithDescs("Tools", toolNames, descs),
 		}
+
+		// Mark SDD workflow items with a "Recommended" badge and pre-select them.
+		wfCat := &categories[3]
+		for _, item := range wfCat.Items {
+			lower := strings.ToLower(item)
+			if lower == "sdd" || strings.HasPrefix(lower, "sdd-") || strings.HasPrefix(lower, "sdd ") {
+				wfCat.Badges[item] = "Recommended"
+				wfCat.Selected[item] = true
+				if !wfCat.IsOn {
+					wfCat.IsOn = true
+				}
+			}
+		}
+
+		// Pre-select engram MCP (important for SDD workflow).
+		mcpCat := &categories[2]
+		for _, item := range mcpCat.Items {
+			if strings.ToLower(item) == "engram" {
+				mcpCat.Selected[item] = true
+				if !mcpCat.IsOn {
+					mcpCat.IsOn = true
+				}
+				break
+			}
+		}
+
 		selections[i] = RepoSelection{
 			Source:     r.Source,
 			Categories: categories,
@@ -198,6 +242,14 @@ func NewSelectModel(repos []ScannedRepoInput) *SelectModel {
 // EnableRecommendations enables the "Confirm with AI recommendations" button.
 func (m *SelectModel) EnableRecommendations() {
 	m.recEnabled = true
+}
+
+// DisableRecommendations shows the AI button in a disabled/greyed-out state.
+// The button is visible but not interactive — the cursor skips it and Enter
+// does nothing on it. Use this when no AI agent is available on PATH.
+func (m *SelectModel) DisableRecommendations() {
+	m.recEnabled = true
+	m.recDisabled = true
 }
 
 // restoreSelection sets each item's Selected state from a previous SelectionResult.
@@ -261,7 +313,7 @@ func buildCategoryWithDescsAndHeaders(kind string, items []string, descs map[str
 			catHeaders[item] = true
 			continue // headers are not selectable
 		}
-		sel[item] = true
+		sel[item] = false
 		if d, ok := descs[item]; ok {
 			catDescs[item] = d
 		}
@@ -270,7 +322,7 @@ func buildCategoryWithDescsAndHeaders(kind string, items []string, descs map[str
 		Kind:     kind,
 		Items:    items,
 		Selected: sel,
-		IsOn:     true,
+		IsOn:     false,
 		Descs:    catDescs,
 		Badges:   map[string]string{},
 		Headers:  catHeaders,
@@ -288,6 +340,9 @@ func (m *SelectModel) Result() SelectionResult {
 		skills := repo.Categories[0]
 		if skills.IsOn {
 			for _, item := range skills.Items {
+				if skills.Headers[item] {
+					continue // skip non-interactive header labels
+				}
 				if skills.Selected[item] {
 					rr.SelectedSkills = append(rr.SelectedSkills, item)
 				}
@@ -411,9 +466,13 @@ func (m SelectModel) updateCollapsed(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// If any item is selected, deselect all. Otherwise, select all.
 			anySelected := cat.selectedCount() > 0
 			for _, item := range cat.Items {
+				if cat.Headers[item] {
+					continue // headers are not selectable
+				}
 				cat.Selected[item] = !anySelected
 			}
 			cat.IsOn = !anySelected
+			m.errorMsg = "" // clear validation error on any toggle
 		}
 
 	case "enter":
@@ -424,7 +483,11 @@ func (m SelectModel) updateCollapsed(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		if m.isConfirmRow(m.cursor) {
-			// "Confirm selection" button pressed.
+			// "Confirm selection" button pressed — validate at least 1 item selected.
+			if m.totalSelectedCount() == 0 {
+				m.errorMsg = "Please select at least 1 item"
+				return m, nil
+			}
 			m.done = true
 			return m, tea.Quit
 		}
@@ -544,6 +607,7 @@ func (m SelectModel) updateExpanded(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				}
 				cat.Selected[item] = !allOn
 			}
+			m.errorMsg = "" // clear validation error on any toggle
 		} else {
 			idx := exp.cursor - 1
 			if idx < len(filteredItems) {
@@ -551,6 +615,7 @@ func (m SelectModel) updateExpanded(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				// Do not toggle header items — they are non-interactive labels.
 				if !cat.Headers[item] {
 					cat.Selected[item] = !cat.Selected[item]
+					m.errorMsg = "" // clear validation error on any toggle
 				}
 			}
 		}
@@ -596,6 +661,9 @@ func (m *SelectModel) renderCollapsed() string {
 	sb.WriteString("\n")
 	sb.WriteString("  ")
 	sb.WriteString(tuistyles.StyleInfo.Render("↑/↓ navigate  Space toggle  Enter expand/confirm"))
+	sb.WriteString("\n")
+	sb.WriteString("  ")
+	sb.WriteString(tuistyles.StyleSuccess.Render("★ SDD workflow is recommended for spec-driven development"))
 	sb.WriteString("\n\n")
 
 	for ri, repo := range m.repos {
@@ -622,7 +690,7 @@ func (m *SelectModel) renderCollapsed() string {
 			selectable := cat.selectableCount()
 			var checkBox string
 			if sel == selectable && sel > 0 {
-				checkBox = tuistyles.StyleSuccess.Render("[x]")
+				checkBox = tuistyles.StyleSuccess.Render("[•]")
 			} else if sel > 0 {
 				checkBox = tuistyles.StyleHighlight.Render("[-]")
 			} else {
@@ -678,11 +746,31 @@ func (m *SelectModel) renderCollapsed() string {
 	if m.recEnabled {
 		recIdx := confirmIdx + 1
 		sb.WriteString("  ")
-		if m.cursor == recIdx {
+		if m.recDisabled {
+			// Disabled: visible but not interactive — render with dim/info style.
+			disabledBtn := lipgloss.NewStyle().
+				Foreground(tuistyles.ColorDim).
+				Padding(0, 2)
+			sb.WriteString(disabledBtn.Render(aiLabel))
+		} else if m.cursor == recIdx {
 			sb.WriteString(focusedBtn.Render(aiLabel))
 		} else {
 			sb.WriteString(blurredBtn.Render(aiLabel))
 		}
+	}
+
+	sb.WriteString("\n")
+
+	if m.recEnabled && m.recDisabled {
+		sb.WriteString("  ")
+		sb.WriteString(tuistyles.StyleInfo.Render("Requires Claude or OpenCode on PATH"))
+		sb.WriteString("\n")
+	}
+
+	if m.errorMsg != "" {
+		sb.WriteString("\n")
+		sb.WriteString("  ")
+		sb.WriteString(tuistyles.StyleError.Render("⚠ " + m.errorMsg))
 	}
 
 	sb.WriteString("\n\n")
@@ -735,7 +823,7 @@ func (m *SelectModel) renderExpanded() string {
 
 	allCheck := tuistyles.StyleError.Render("[ ]")
 	if allOn {
-		allCheck = tuistyles.StyleSuccess.Render("[x]")
+		allCheck = tuistyles.StyleSuccess.Render("[•]")
 	}
 
 	allCursor := "  "
@@ -780,7 +868,7 @@ func (m *SelectModel) renderExpanded() string {
 
 		itemCheck := tuistyles.StyleError.Render("[ ]")
 		if cat.Selected[item] {
-			itemCheck = tuistyles.StyleSuccess.Render("[x]")
+			itemCheck = tuistyles.StyleSuccess.Render("[•]")
 		}
 
 		itemCursor := "  "
@@ -903,14 +991,18 @@ func BuildSkillsShInput(detected []recommend.DetectedTech) *ScannedRepoInput {
 // via detect.Analyze and appends a Skills.sh Curated catalog entry to the repo
 // list when matching skills are found. If detection fails or returns no matches,
 // the TUI is shown without the skills.sh section.
-func RunSelectModel(repos []ScannedRepoInput, enableRecommendations bool, projectDir string, previousSelection ...SelectionResult) (SelectModelResult, error) {
+func RunSelectModel(repos []ScannedRepoInput, enableRecommendations bool, agentAvailable bool, projectDir string, previousSelection ...SelectionResult) (SelectModelResult, error) {
 	if len(repos) == 0 {
 		return SelectModelResult{}, nil
 	}
 
 	m := NewSelectModel(repos)
 	if enableRecommendations {
-		m.EnableRecommendations()
+		if agentAvailable {
+			m.EnableRecommendations()
+		} else {
+			m.DisableRecommendations()
+		}
 	}
 
 	// Restore previous selection state (for go-back loop).

--- a/internal/tui/steps/select.go
+++ b/internal/tui/steps/select.go
@@ -10,6 +10,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/davidarce/devrune/internal/model"
+	"github.com/davidarce/devrune/internal/recommend"
 	"github.com/davidarce/devrune/internal/tui/tuistyles"
 )
 
@@ -24,6 +25,10 @@ type ScannedRepoInput struct {
 	Tools             []model.ToolDef          // available tool definitions
 	Descs             map[string]string        // item name → description
 	MCPFiles          map[string]string        // MCP name → filename (e.g. "engram" → "engram.yaml")
+	// SkillHeaders marks which skill items are non-interactive tech header labels
+	// (e.g. "Spring Boot", "Java"). Headers are not selectable and do not count
+	// toward selected totals. Only applies to the Skills category.
+	SkillHeaders map[string]bool
 }
 
 // SelectionResult holds the final user selection after the select step.
@@ -50,13 +55,33 @@ type CategorySelection struct {
 	IsOn     bool              // category-level toggle (default: true)
 	Descs    map[string]string // item name → description (optional)
 	Badges   map[string]string // item name → badge text (e.g. "Recommended"), optional
+	// Headers marks which items are non-interactive section header labels.
+	// Headers are not selectable, not counted in selectedCount, and
+	// not toggled by select-all. They are rendered as plain text labels.
+	Headers map[string]bool
 }
 
 // selectedCount returns how many individual items are selected.
+// Header items (non-interactive labels) are excluded from the count.
 func (c *CategorySelection) selectedCount() int {
 	count := 0
 	for _, item := range c.Items {
+		if c.Headers[item] {
+			continue // skip non-interactive header labels
+		}
 		if c.Selected[item] {
+			count++
+		}
+	}
+	return count
+}
+
+// selectableCount returns the number of items that can actually be selected
+// (excludes header labels).
+func (c *CategorySelection) selectableCount() int {
+	count := 0
+	for _, item := range c.Items {
+		if !c.Headers[item] {
 			count++
 		}
 	}
@@ -102,6 +127,19 @@ func (m *SelectModel) flatLen() int {
 	return len(m.repos)*5 + buttons
 }
 
+// isEmptyCategory reports whether the given flat cursor index corresponds to
+// a category with zero selectable items (hidden by the empty-category filter).
+func (m *SelectModel) isEmptyCategory(cursor int) bool {
+	if m.isConfirmRow(cursor) {
+		return false
+	}
+	ri, ci := repoAndCat(cursor)
+	if ri >= len(m.repos) || ci >= len(m.repos[ri].Categories) {
+		return false
+	}
+	return m.repos[ri].Categories[ci].selectableCount() == 0
+}
+
 // isConfirmRow reports whether the given flat cursor index is the confirm button.
 func (m *SelectModel) isConfirmRow(cursor int) bool {
 	return cursor >= len(m.repos)*5
@@ -135,7 +173,7 @@ func NewSelectModel(repos []ScannedRepoInput) *SelectModel {
 			}
 		}
 		categories := [5]CategorySelection{
-			buildCategoryWithDescs("Skills", r.Skills, descs),
+			buildCategoryWithDescsAndHeaders("Skills", r.Skills, descs, r.SkillHeaders),
 			buildCategoryWithDescs("Rules", r.Rules, descs),
 			buildCategoryWithDescs("MCPs", r.MCPs, descs),
 			buildCategoryWithDescs("Workflows", r.Workflows, descs),
@@ -208,9 +246,21 @@ func toStringSet(items []string) map[string]bool {
 
 // buildCategoryWithDescs creates a CategorySelection with all items selected by default.
 func buildCategoryWithDescs(kind string, items []string, descs map[string]string) CategorySelection {
+	return buildCategoryWithDescsAndHeaders(kind, items, descs, nil)
+}
+
+// buildCategoryWithDescsAndHeaders creates a CategorySelection with all selectable items
+// selected by default. Header items (marked in headers map) are not added to
+// the Selected map and do not count toward selection totals.
+func buildCategoryWithDescsAndHeaders(kind string, items []string, descs map[string]string, headers map[string]bool) CategorySelection {
 	sel := make(map[string]bool, len(items))
 	catDescs := make(map[string]string)
+	catHeaders := make(map[string]bool)
 	for _, item := range items {
+		if headers[item] {
+			catHeaders[item] = true
+			continue // headers are not selectable
+		}
 		sel[item] = true
 		if d, ok := descs[item]; ok {
 			catDescs[item] = d
@@ -223,6 +273,7 @@ func buildCategoryWithDescs(kind string, items []string, descs map[string]string
 		IsOn:     true,
 		Descs:    catDescs,
 		Badges:   map[string]string{},
+		Headers:  catHeaders,
 	}
 }
 
@@ -319,11 +370,19 @@ func (m SelectModel) updateCollapsed(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "up", "k":
 		if m.cursor > 0 {
 			m.cursor--
+			// Skip empty categories (hidden by empty-category filter).
+			for m.cursor > 0 && m.isEmptyCategory(m.cursor) {
+				m.cursor--
+			}
 		}
 
 	case "down", "j":
 		if m.cursor < m.flatLen()-1 {
 			m.cursor++
+			// Skip empty categories (hidden by empty-category filter).
+			for m.cursor < m.flatLen()-1 && m.isEmptyCategory(m.cursor) {
+				m.cursor++
+			}
 		}
 
 	case "left", "h":
@@ -440,32 +499,59 @@ func (m SelectModel) updateExpanded(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "up", "k":
 		if exp.cursor > 0 {
 			exp.cursor--
+			// Skip non-interactive header rows.
+			for exp.cursor > 0 {
+				idx := exp.cursor - 1
+				if idx < len(filteredItems) && cat.Headers[filteredItems[idx]] {
+					exp.cursor--
+				} else {
+					break
+				}
+			}
 		}
 
 	case "down", "j":
 		if exp.cursor < len(filteredItems) {
 			// +1 for the "select all" row.
 			exp.cursor++
+			// Skip non-interactive header rows.
+			for exp.cursor > 0 && exp.cursor <= len(filteredItems) {
+				idx := exp.cursor - 1
+				if idx < len(filteredItems) && cat.Headers[filteredItems[idx]] {
+					exp.cursor++
+				} else {
+					break
+				}
+			}
 		}
 
 	case " ", "space":
 		if exp.cursor == 0 {
-			// Toggle "select all".
+			// Toggle "select all" — skip header items.
 			allOn := true
 			for _, item := range filteredItems {
+				if cat.Headers[item] {
+					continue // headers are not selectable
+				}
 				if !cat.Selected[item] {
 					allOn = false
 					break
 				}
 			}
 			for _, item := range filteredItems {
+				if cat.Headers[item] {
+					continue // headers are not togglable
+				}
 				cat.Selected[item] = !allOn
 			}
 		} else {
 			idx := exp.cursor - 1
 			if idx < len(filteredItems) {
 				item := filteredItems[idx]
-				cat.Selected[item] = !cat.Selected[item]
+				// Do not toggle header items — they are non-interactive labels.
+				if !cat.Headers[item] {
+					cat.Selected[item] = !cat.Selected[item]
+				}
 			}
 		}
 
@@ -517,6 +603,13 @@ func (m *SelectModel) renderCollapsed() string {
 		sb.WriteString("\n")
 
 		for ci, cat := range repo.Categories {
+			// Empty-category filter: skip categories with zero selectable items.
+			// This applies to ALL sources — starter-catalog repos with no workflows,
+			// skills.sh groups with only Skills, etc.
+			if cat.selectableCount() == 0 {
+				continue
+			}
+
 			flatIdx := ri*5 + ci
 			isFocused := m.cursor == flatIdx
 
@@ -526,8 +619,9 @@ func (m *SelectModel) renderCollapsed() string {
 			}
 
 			sel := cat.selectedCount()
+			selectable := cat.selectableCount()
 			var checkBox string
-			if sel == len(cat.Items) && sel > 0 {
+			if sel == selectable && sel > 0 {
 				checkBox = tuistyles.StyleSuccess.Render("[x]")
 			} else if sel > 0 {
 				checkBox = tuistyles.StyleHighlight.Render("[-]")
@@ -535,12 +629,7 @@ func (m *SelectModel) renderCollapsed() string {
 				checkBox = tuistyles.StyleError.Render("[ ]")
 			}
 
-			var count string
-			if len(cat.Items) == 0 {
-				count = tuistyles.StyleInfo.Render("(none)")
-			} else {
-				count = tuistyles.StyleInfo.Render(fmt.Sprintf("(%d/%d)", sel, len(cat.Items)))
-			}
+			count := tuistyles.StyleInfo.Render(fmt.Sprintf("(%d/%d)", sel, selectable))
 
 			line := fmt.Sprintf("│  %s%s %s %s", cursor, checkBox, cat.Kind, count)
 
@@ -629,9 +718,15 @@ func (m *SelectModel) renderExpanded() string {
 		sb.WriteString("\n")
 	}
 
-	// "Select all" row.
-	allOn := len(filteredItems) > 0
+	// "Select all" row — headers are excluded from the all-on check.
+	selectableFiltered := make([]string, 0, len(filteredItems))
 	for _, item := range filteredItems {
+		if !cat.Headers[item] {
+			selectableFiltered = append(selectableFiltered, item)
+		}
+	}
+	allOn := len(selectableFiltered) > 0
+	for _, item := range selectableFiltered {
 		if !cat.Selected[item] {
 			allOn = false
 			break
@@ -674,6 +769,14 @@ func (m *SelectModel) renderExpanded() string {
 	for idx := start; idx < end; idx++ {
 		item := filteredItems[idx]
 		isFocused := (exp.cursor == idx+1)
+
+		// Header items are non-interactive tech labels (e.g. "Spring Boot", "Java").
+		// Render them as plain indented text — no checkbox, no cursor, not selectable.
+		if cat.Headers[item] {
+			sb.WriteString(tuistyles.StyleInfo.Render(fmt.Sprintf("│    %s", item)))
+			sb.WriteString("\n")
+			continue
+		}
 
 		itemCheck := tuistyles.StyleError.Render("[ ]")
 		if cat.Selected[item] {
@@ -744,9 +847,63 @@ type SelectModelResult struct {
 	UseRecommendations bool
 }
 
+// buildSkillsShInput constructs a ScannedRepoInput for the Skills.sh Curated catalog
+// from a slice of DetectedTech values. All detected tech skills are merged into a
+// single Skills category. Within the category, tech names act as non-interactive
+// header labels grouping their respective skills.
+//
+// Returns nil if detected is empty or contains no skills.
+func BuildSkillsShInput(detected []recommend.DetectedTech) *ScannedRepoInput {
+	if len(detected) == 0 {
+		return nil
+	}
+
+	var skillItems []string
+	headers := make(map[string]bool)
+	descs := make(map[string]string)
+
+	for _, tech := range detected {
+		if len(tech.Skills) == 0 {
+			continue
+		}
+		// Emit tech name as a non-interactive header label.
+		skillItems = append(skillItems, tech.Framework)
+		headers[tech.Framework] = true
+
+		// Emit each skill under this tech.
+		for _, ref := range tech.Skills {
+			name := recommend.SkillName(ref.Path)
+			skillItems = append(skillItems, name)
+			if ref.Description != "" {
+				descs[name] = ref.Description
+			}
+		}
+	}
+
+	if len(skillItems) == 0 {
+		return nil
+	}
+
+	return &ScannedRepoInput{
+		Source:       "Skills.sh Curated",
+		Skills:       skillItems,
+		Descs:        descs,
+		SkillHeaders: headers,
+	}
+}
+
 // RunSelectModel runs the Bubbletea selection model and returns the result.
 // previousSelection, if non-nil, restores the user's prior selections (for go-back support).
-func RunSelectModel(repos []ScannedRepoInput, enableRecommendations bool, previousSelection ...SelectionResult) (SelectModelResult, error) {
+//
+// projectDir is the root directory of the project being configured. It is used
+// to detect the tech stack for skills.sh curated skill injection. Pass an empty
+// string to skip detection (useful in tests or when the directory is unknown).
+//
+// Before building the model, RunSelectModel detects the project's tech stack
+// via detect.Analyze and appends a Skills.sh Curated catalog entry to the repo
+// list when matching skills are found. If detection fails or returns no matches,
+// the TUI is shown without the skills.sh section.
+func RunSelectModel(repos []ScannedRepoInput, enableRecommendations bool, projectDir string, previousSelection ...SelectionResult) (SelectModelResult, error) {
 	if len(repos) == 0 {
 		return SelectModelResult{}, nil
 	}

--- a/internal/tui/steps/select_test.go
+++ b/internal/tui/steps/select_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+
+package steps
+
+import (
+	"testing"
+
+	"github.com/davidarce/devrune/internal/recommend"
+)
+
+// ── BuildSkillsShInput ────────────────────────────────────────────────────────
+
+func TestBuildSkillsShInput_EmptyDetected(t *testing.T) {
+	got := BuildSkillsShInput(nil)
+	if got != nil {
+		t.Errorf("BuildSkillsShInput(nil): want nil, got %+v", got)
+	}
+
+	got = BuildSkillsShInput([]recommend.DetectedTech{})
+	if got != nil {
+		t.Errorf("BuildSkillsShInput([]): want nil, got %+v", got)
+	}
+}
+
+func TestBuildSkillsShInput_TechWithNoSkillsReturnedNil(t *testing.T) {
+	detected := []recommend.DetectedTech{
+		{Framework: "React", Skills: nil},
+	}
+	got := BuildSkillsShInput(detected)
+	if got != nil {
+		t.Errorf("BuildSkillsShInput with no skills: want nil, got %+v", got)
+	}
+}
+
+func TestBuildSkillsShInput_SingleTechSingleSkill(t *testing.T) {
+	detected := []recommend.DetectedTech{
+		{
+			Framework: "React",
+			Skills: []recommend.SkillRef{
+				{Path: "vercel-labs/agent-skills/vercel-react-best-practices", Description: "React best practices"},
+			},
+		},
+	}
+
+	got := BuildSkillsShInput(detected)
+	if got == nil {
+		t.Fatal("BuildSkillsShInput: want non-nil result, got nil")
+	}
+
+	if got.Source != "Skills.sh Curated" {
+		t.Errorf("Source: want %q, got %q", "Skills.sh Curated", got.Source)
+	}
+
+	// Items: header "React" + skill "vercel-react-best-practices"
+	if len(got.Skills) != 2 {
+		t.Fatalf("Skills length: want 2, got %d: %v", len(got.Skills), got.Skills)
+	}
+	if got.Skills[0] != "React" {
+		t.Errorf("Skills[0]: want %q (header), got %q", "React", got.Skills[0])
+	}
+	if got.Skills[1] != "vercel-react-best-practices" {
+		t.Errorf("Skills[1]: want %q, got %q", "vercel-react-best-practices", got.Skills[1])
+	}
+
+	// Header map must mark the framework name as a header.
+	if !got.SkillHeaders["React"] {
+		t.Error("SkillHeaders[React]: want true (header label), got false")
+	}
+	if got.SkillHeaders["vercel-react-best-practices"] {
+		t.Error("SkillHeaders[vercel-react-best-practices]: want false (selectable), got true")
+	}
+
+	// Description must be populated.
+	if got.Descs["vercel-react-best-practices"] != "React best practices" {
+		t.Errorf("Descs[vercel-react-best-practices]: want %q, got %q",
+			"React best practices", got.Descs["vercel-react-best-practices"])
+	}
+}
+
+func TestBuildSkillsShInput_MultipleTechs(t *testing.T) {
+	detected := []recommend.DetectedTech{
+		{
+			Framework: "React",
+			Skills: []recommend.SkillRef{
+				{Path: "vercel-labs/agent-skills/vercel-react-best-practices", Description: "React"},
+				{Path: "vercel-labs/agent-skills/vercel-composition-patterns", Description: "Composition"},
+			},
+		},
+		{
+			Framework: "Spring Boot",
+			Skills: []recommend.SkillRef{
+				{Path: "github/awesome-copilot/spring-boot-docs", Description: "Spring Boot docs"},
+			},
+		},
+	}
+
+	got := BuildSkillsShInput(detected)
+	if got == nil {
+		t.Fatal("BuildSkillsShInput: want non-nil result, got nil")
+	}
+
+	// Expected order: React (header), react-skill-1, react-skill-2, Spring Boot (header), spring-skill
+	wantItems := []string{
+		"React",
+		"vercel-react-best-practices",
+		"vercel-composition-patterns",
+		"Spring Boot",
+		"spring-boot-docs",
+	}
+	if len(got.Skills) != len(wantItems) {
+		t.Fatalf("Skills length: want %d, got %d: %v", len(wantItems), len(got.Skills), got.Skills)
+	}
+	for i, want := range wantItems {
+		if got.Skills[i] != want {
+			t.Errorf("Skills[%d]: want %q, got %q", i, want, got.Skills[i])
+		}
+	}
+
+	// Both tech names must be headers.
+	if !got.SkillHeaders["React"] {
+		t.Error("SkillHeaders[React]: want true")
+	}
+	if !got.SkillHeaders["Spring Boot"] {
+		t.Error("SkillHeaders[Spring Boot]: want true")
+	}
+}
+
+func TestBuildSkillsShInput_EmptyDescriptionNotAdded(t *testing.T) {
+	detected := []recommend.DetectedTech{
+		{
+			Framework: "React",
+			Skills: []recommend.SkillRef{
+				{Path: "vercel-labs/agent-skills/vercel-react-best-practices", Description: ""},
+			},
+		},
+	}
+
+	got := BuildSkillsShInput(detected)
+	if got == nil {
+		t.Fatal("want non-nil result")
+	}
+
+	if _, ok := got.Descs["vercel-react-best-practices"]; ok {
+		t.Error("Descs: want no entry for skill with empty description, but found one")
+	}
+}
+
+func TestBuildSkillsShInput_TwoSegmentPath(t *testing.T) {
+	detected := []recommend.DetectedTech{
+		{
+			Framework: "Misc",
+			Skills: []recommend.SkillRef{
+				{Path: "owner/repo", Description: "two-segment path"},
+			},
+		},
+	}
+
+	got := BuildSkillsShInput(detected)
+	if got == nil {
+		t.Fatal("want non-nil result")
+	}
+
+	// Short name of "owner/repo" is "repo".
+	found := false
+	for _, item := range got.Skills {
+		if item == "repo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want skill name %q in items %v", "repo", got.Skills)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a static, team-curated catalog of [skills.sh](https://skills.sh) skills grouped by technology
- Skills.sh Curated Catalog appears as a toggleable source in Step 2 (Repository Sources)
- When enabled, DevRune detects the project tech stack via `detect.Analyze()` and surfaces audit-verified skills (ATH, Socket, Snyk — all PASS) in Step 3
- 17 entries across 12 frameworks (React, Next.js, Vue, Angular, Svelte, Tailwind, Spring Boot, Django, FastAPI, Astro, Remix) + 5 languages (Java, Kotlin, Go, Python, TypeScript)
- Zero runtime API dependency — the registry is a compiled-in Go data structure
- Tech detection runs inside the scan spinner (no UI freeze)

## Changes

### New files (`internal/recommend/`)
- `skillssh_types.go` — `FrameworkSkills`, `SkillRef`, `DetectedTech`, `CatalogFetcher` interface
- `skillssh_registry.go` — Static registry of audit-verified skills.sh skills
- `skillssh_catalog.go` — `StaticCatalog` adapter with `FetchByFrameworks()` and `FetchByProfile()`
- `skillssh_convert.go` — `SkillRefToPackageRef()` conversion
- `skillssh_*_test.go` — 34+ unit tests

### Modified files
- `internal/tui/steps/repos.go` — New `knownSource` for Skills.sh Curated Catalog
- `internal/tui/steps/select.go` — TUI integration with tech-grouped headers, empty-category filter, cursor skip logic
- `internal/tui/app.go` — Skills.sh detection runs inside scan spinner, sentinel filtering
- `internal/cli/pipeline.go` — Sentinel expansion for skills.sh PackageRef entries
- `README.md` — New "Skills.sh Curated Catalog" section

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint` passes (0 issues)
- [x] Manual testing: TUI shows skills.sh catalog for Go, React+TS, and Spring Boot+Java projects
- [x] Manual testing: `devrune resolve` + `devrune install` works with selected skills.sh skills
- [x] Verified all 18 skills have audit PASS (ATH: safe, Socket: safe, Snyk: low)
- [x] Verify cursor navigation skips empty categories smoothly
- [x] Verify toggling Skills.sh Curated off in Step 2 removes it from Step 3

Closes davidarce/devrune-starter-catalog#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)