### PR TITLE
feat(tui): highlight SDD workflow in wizard (#36)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,24 @@ build:
 build-debug:
 	go build -ldflags='-X main.version=$(VERSION) -X main.commit=$(COMMIT)' -o $(BINARY) $(CMD)
 
-## install: Build and install to INSTALL_DIR (default: /usr/local/bin)
+## install: Build and install to INSTALL_DIR (default: ~/.local/bin)
 install: build
 	@mkdir -p $(INSTALL_DIR)
 	@cp $(BINARY) $(INSTALL_DIR)/$(BINARY)
 	@chmod 755 $(INSTALL_DIR)/$(BINARY)
-	@echo "$(BINARY) installed to $(INSTALL_DIR)/$(BINARY)"
+	@echo "✓ $(BINARY) installed to $(INSTALL_DIR)/$(BINARY)"
+	@# PATH check — warn if INSTALL_DIR is not in $PATH.
+	@case ":$$PATH:" in *":$(INSTALL_DIR):"*) ;; \
+		*) printf '\033[33m!\033[0m %s is not in your PATH.\n' "$(INSTALL_DIR)"; \
+		   printf '  Add: \033[2mexport PATH="%s:$$PATH"\033[0m to your shell profile.\n' "$(INSTALL_DIR)" ;; \
+	esac
+	@# Shadow detection — warn if a different devrune binary precedes ours in PATH.
+	@resolved="$$(command -v $(BINARY) 2>/dev/null || true)"; \
+	expected="$(INSTALL_DIR)/$(BINARY)"; \
+	if [ -n "$$resolved" ] && [ "$$resolved" != "$$expected" ]; then \
+		printf '\033[33m!\033[0m Shadow binary: `which $(BINARY)` → %s\n' "$$resolved"; \
+		printf '  That path precedes %s in PATH. Remove it or reorder PATH to use the fresh build.\n' "$(INSTALL_DIR)"; \
+	fi
 
 ## uninstall: Remove binary from INSTALL_DIR
 uninstall:

--- a/internal/cli/menu.go
+++ b/internal/cli/menu.go
@@ -203,15 +203,18 @@ func showStatusInMenu(cmd *cobra.Command) error {
 			sb.WriteString("Status:           manifest not found")
 		} else if m, parseErr := parse.ParseManifest(manifestData); parseErr != nil {
 			sb.WriteString("Status:           manifest parse error")
-		} else if serialized, serErr := parse.SerializeManifest(m); serErr != nil {
-			sb.WriteString("Status:           serialization error")
 		} else {
-			sum := sha256.Sum256(serialized)
-			currentHash := fmt.Sprintf("sha256:%x", sum)
-			if currentHash == s.LockHash {
-				sb.WriteString("Status:           ✓ fresh")
+			m.Packages = expandSkillsShPackages(m.Packages)
+			if serialized, serErr := parse.SerializeManifest(m); serErr != nil {
+				sb.WriteString("Status:           serialization error")
 			} else {
-				sb.WriteString("Status:           ⚠ stale (manifest changed since last install)")
+				sum := sha256.Sum256(serialized)
+				currentHash := fmt.Sprintf("sha256:%x", sum)
+				if currentHash == s.LockHash {
+					sb.WriteString("Status:           ✓ fresh")
+				} else {
+					sb.WriteString("Status:           ⚠ stale (manifest changed since last install)")
+				}
 			}
 		}
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -84,6 +84,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Expand Skills.sh Curated sentinels before hashing — the resolver does
+	// this expansion before computing manifestHash, so the status check must
+	// match to avoid false "stale" reports.
+	manifest.Packages = expandSkillsShPackages(manifest.Packages)
+
 	// Compute manifest hash the same way the resolver does.
 	serialized, err := parse.SerializeManifest(manifest)
 	if err != nil {

--- a/internal/materialize/renderers/copilot.go
+++ b/internal/materialize/renderers/copilot.go
@@ -44,6 +44,14 @@ var copilotSubAgentTools = map[string][]string{
 	"sdd-plan":      {"read", "search", "edit", "execute"},
 	"sdd-implement": {"read", "search", "edit", "execute"},
 	"sdd-review":    {"read", "search", "execute"},
+	// Adviser roles — read and search only; they analyse the plan and their SKILL.md.
+	"architect-adviser":         {"read", "search"},
+	"api-first-adviser":         {"read", "search"},
+	"unit-test-adviser":         {"read", "search"},
+	"integration-test-adviser":  {"read", "search"},
+	"component-adviser":         {"read", "search"},
+	"frontend-test-adviser":     {"read", "search"},
+	"web-accessibility-adviser": {"read", "search"},
 }
 
 // copilotBodyReplacements maps Claude Code MCP shorthand tool calls to Copilot
@@ -485,8 +493,10 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	}
 
 	// T018: Generate native sub-agent .agent.md files for each subagent role.
+	// Skip sentinel roles (e.g. sdd-adviser with skill "*-adviser") — these exist
+	// only for model placeholder generation, not for .agent.md synthesis.
 	for _, role := range wf.Components.Roles {
-		if role.Kind != "subagent" || role.Skill == "" {
+		if role.Kind != "subagent" || role.Skill == "" || strings.Contains(role.Skill, "*") {
 			continue
 		}
 		skillSrcDir := filepath.Join(cachePath, role.Skill)
@@ -495,6 +505,52 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: generate sub-agent %q: %w", role.Name, err)
 		}
 		managedPaths = append(managedPaths, dstPath)
+	}
+
+	// Generate lightweight .agent.md wrappers for adviser skills installed in skillsBase.
+	// Advisers are not workflow roles but need to be invocable as @agent-name in
+	// Copilot's guidance loop. The wrapper references the SKILL.md in skills/ rather
+	// than embedding the full content (avoiding duplication).
+	if adviserEntries, err := os.ReadDir(skillsBase); err == nil {
+		for _, entry := range adviserEntries {
+			if !entry.IsDir() || !strings.HasSuffix(entry.Name(), "-adviser") {
+				continue
+			}
+			adviserName := entry.Name()
+			agentPath := filepath.Join(agentsBase, adviserName+".agent.md")
+			// Skip if already generated as a workflow role.
+			if _, err := os.Stat(agentPath); err == nil {
+				continue
+			}
+			description := skillDescriptionForRole(adviserName)
+			if description == "" {
+				description = adviserName + " specialist adviser"
+			}
+			tools := copilotSubAgentTools[adviserName]
+			if len(tools) == 0 {
+				tools = []string{"read"}
+			}
+			fm := map[string]interface{}{
+				"name":                     adviserName,
+				"description":              description,
+				"tools":                    tools,
+				"user-invocable":           false,
+				"disable-model-invocation": false,
+			}
+			skillPath := filepath.Join(skillsBase, adviserName, "SKILL.md")
+			body := fmt.Sprintf("You are a specialist adviser. Read your skill file at `%s` and follow its instructions.\n", skillPath)
+			out, err := parse.SerializeFrontmatter(fm, body)
+			if err != nil {
+				continue
+			}
+			if err := os.MkdirAll(filepath.Dir(agentPath), 0o755); err != nil {
+				continue
+			}
+			if err := os.WriteFile(agentPath, out, 0o644); err != nil {
+				continue
+			}
+			managedPaths = append(managedPaths, agentPath)
+		}
 	}
 
 	// Capture registry content for catalog injection; apply shared placeholder replacements.
@@ -650,6 +706,20 @@ func skillDescriptionForRole(skill string) string {
 		return "SDD Implement sub-agent"
 	case "sdd-review":
 		return "SDD Review sub-agent"
+	case "architect-adviser":
+		return "Clean architecture adviser: hexagonal, DDD, ports and adapters"
+	case "api-first-adviser":
+		return "API-first design adviser: OpenAPI, REST conventions, error models"
+	case "unit-test-adviser":
+		return "Unit test adviser: test structure, mocking, Given-When-Then"
+	case "integration-test-adviser":
+		return "Integration test adviser: adapter testing, external service mocking"
+	case "component-adviser":
+		return "React component adviser: composition, hooks, state management"
+	case "frontend-test-adviser":
+		return "Frontend test adviser: React Testing Library, Vitest, Cypress"
+	case "web-accessibility-adviser":
+		return "Web accessibility adviser: WCAG 2.1 AA, ARIA, keyboard navigation"
 	default:
 		return skill + " sub-agent"
 	}

--- a/internal/materialize/renderers/copilot.go
+++ b/internal/materialize/renderers/copilot.go
@@ -537,8 +537,9 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 				"user-invocable":           false,
 				"disable-model-invocation": false,
 			}
-			skillPath := filepath.Join(skillsBase, adviserName, "SKILL.md")
-			body := fmt.Sprintf("You are a specialist adviser. Read your skill file at `%s` and follow its instructions.\n", skillPath)
+			// Use workspace-relative path (not absolute) so the .agent.md is portable.
+			skillRelPath := filepath.Join(workspaceRoot, r.def.SkillDir, adviserName, "SKILL.md")
+			body := fmt.Sprintf("You are a specialist adviser. Read your skill file at `%s` and follow its instructions.\n", skillRelPath)
 			out, err := parse.SerializeFrontmatter(fm, body)
 			if err != nil {
 				continue

--- a/internal/materialize/renderers/helpers.go
+++ b/internal/materialize/renderers/helpers.go
@@ -642,6 +642,7 @@ func buildWorkflowPlaceholderReplacements(
 		"PLANNER":     "{SDD_MODEL_PLAN}",
 		"IMPLEMENTER": "{SDD_MODEL_IMPLEMENT}",
 		"REVIEWER":    "{SDD_MODEL_REVIEW}",
+		"ADVISER":     "{SDD_MODEL_ADVISER}",
 	}
 
 	for _, role := range wf.Components.Roles {

--- a/internal/materialize/renderers/hooks.go
+++ b/internal/materialize/renderers/hooks.go
@@ -68,11 +68,7 @@ func copyHookScriptAssets(hookData map[string]interface{}, cachePath, workspaceR
 
 		// cleanPath is the destination-relative path (e.g. ".claude/hooks/script.sh").
 		// The source in the cache omits the agent workspace prefix (e.g. "hooks/script.sh").
-		srcRelative := cleanPath
-		wsPrefix := agentWorkspace + "/"
-		if strings.HasPrefix(srcRelative, wsPrefix) {
-			srcRelative = srcRelative[len(wsPrefix):]
-		}
+		srcRelative := strings.TrimPrefix(cleanPath, agentWorkspace+"/")
 
 		srcFile := filepath.Join(cachePath, srcRelative)
 		// workspaceRoot already includes the agent workspace (e.g. ".claude/"),
@@ -139,13 +135,13 @@ func copyFileWithMode(src, dst string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/internal/materialize/renderers/hooks.go
+++ b/internal/materialize/renderers/hooks.go
@@ -68,7 +68,11 @@ func copyHookScriptAssets(hookData map[string]interface{}, cachePath, workspaceR
 
 		// cleanPath is the destination-relative path (e.g. ".claude/hooks/script.sh").
 		// The source in the cache omits the agent workspace prefix (e.g. "hooks/script.sh").
-		srcRelative := strings.TrimPrefix(cleanPath, agentWorkspace+"/")
+		srcRelative := cleanPath
+		wsPrefix := agentWorkspace + "/"
+		if strings.HasPrefix(srcRelative, wsPrefix) {
+			srcRelative = srcRelative[len(wsPrefix):]
+		}
 
 		srcFile := filepath.Join(cachePath, srcRelative)
 		// workspaceRoot already includes the agent workspace (e.g. ".claude/"),
@@ -135,13 +139,13 @@ func copyFileWithMode(src, dst string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = in.Close() }()
+	defer in.Close()
 
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = out.Close() }()
+	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/internal/recommend/adviser_filter.go
+++ b/internal/recommend/adviser_filter.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+
+package recommend
+
+import "github.com/davidarce/devrune/internal/detect"
+
+// AdviserTier classifies an adviser by its applicable project type.
+type AdviserTier string
+
+const (
+	AdviserTierFrontend  AdviserTier = "frontend"
+	AdviserTierBackend   AdviserTier = "backend"
+	AdviserTierUniversal AdviserTier = "universal"
+)
+
+// AdviserClassifications maps known adviser skill names to their tier.
+// Names not in this map default to AdviserTierUniversal (always shown).
+var AdviserClassifications = map[string]AdviserTier{
+	"component-adviser":         AdviserTierFrontend,
+	"web-accessibility-adviser": AdviserTierFrontend,
+	"frontend-test-adviser":     AdviserTierFrontend,
+	"api-first-adviser":         AdviserTierBackend,
+	"architect-adviser":         AdviserTierBackend,
+	"integration-test-adviser":  AdviserTierBackend,
+	"unit-test-adviser":         AdviserTierUniversal,
+}
+
+// frontendFrameworks is the set of framework names (from detect.inferFrameworks)
+// that indicate a frontend-dominant project.
+var frontendFrameworks = map[string]bool{
+	"React": true, "Vue.js": true, "Angular": true,
+	"Svelte": true, "Next.js": true, "Nuxt.js": true,
+	"Astro": true, "Remix": true,
+}
+
+// backendLanguages is the set of primary language names that indicate
+// a backend-dominant project when no frontend framework is detected.
+var backendLanguages = map[string]bool{
+	"Go": true, "Java": true, "Python": true,
+	"Rust": true, "Kotlin": true, "Ruby": true, "PHP": true,
+}
+
+// detectProjectTier returns the dominant tier for the profile.
+// Returns "" when the tier cannot be determined (mixed/unknown → show all).
+func detectProjectTier(profile *detect.ProjectProfile) AdviserTier {
+	if profile == nil {
+		return ""
+	}
+
+	// Check frameworks first: if any frontend framework is detected, classify as frontend.
+	for _, fw := range profile.Frameworks {
+		if frontendFrameworks[fw] {
+			return AdviserTierFrontend
+		}
+	}
+
+	// Find primary language (highest percentage).
+	var primaryLang string
+	var maxPct float64
+	for _, lang := range profile.Languages {
+		if lang.Percentage > maxPct {
+			maxPct = lang.Percentage
+			primaryLang = lang.Name
+		}
+	}
+
+	if backendLanguages[primaryLang] {
+		return AdviserTierBackend
+	}
+
+	return ""
+}
+
+// FilterAdvisersByProfile returns the subset of adviserNames relevant for profile.
+//   - Frontend tier: frontend + universal advisers only
+//   - Backend tier: backend + universal advisers only
+//   - Unknown/mixed tier: returns all adviserNames unchanged
+//   - nil profile: returns all adviserNames unchanged
+func FilterAdvisersByProfile(profile *detect.ProjectProfile, adviserNames []string) []string {
+	tier := detectProjectTier(profile)
+	if tier == "" {
+		return adviserNames
+	}
+
+	result := make([]string, 0, len(adviserNames))
+	for _, name := range adviserNames {
+		classification, known := AdviserClassifications[name]
+		if !known || classification == AdviserTierUniversal || classification == tier {
+			result = append(result, name)
+		}
+	}
+	return result
+}

--- a/internal/recommend/adviser_filter_test.go
+++ b/internal/recommend/adviser_filter_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+
+package recommend
+
+import (
+	"testing"
+
+	"github.com/davidarce/devrune/internal/detect"
+)
+
+func TestDetectProjectTier(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile *detect.ProjectProfile
+		want    AdviserTier
+	}{
+		{
+			name: "frontend project with React framework",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{"React"},
+				Languages:  []detect.LanguageInfo{{Name: "JavaScript", Percentage: 90}},
+			},
+			want: AdviserTierFrontend,
+		},
+		{
+			name: "frontend project with Vue.js framework",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{"Vue.js"},
+				Languages:  []detect.LanguageInfo{{Name: "JavaScript", Percentage: 85}},
+			},
+			want: AdviserTierFrontend,
+		},
+		{
+			name: "frontend project with Next.js framework",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{"Next.js"},
+				Languages:  []detect.LanguageInfo{{Name: "TypeScript", Percentage: 95}},
+			},
+			want: AdviserTierFrontend,
+		},
+		{
+			name: "backend project with Go as primary language",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{},
+				Languages:  []detect.LanguageInfo{{Name: "Go", Percentage: 95}},
+			},
+			want: AdviserTierBackend,
+		},
+		{
+			name: "backend project with Java as primary language",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{},
+				Languages:  []detect.LanguageInfo{{Name: "Java", Percentage: 80}},
+			},
+			want: AdviserTierBackend,
+		},
+		{
+			name: "backend project with Kotlin as primary language",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{},
+				Languages:  []detect.LanguageInfo{{Name: "Kotlin", Percentage: 75}},
+			},
+			want: AdviserTierBackend,
+		},
+		{
+			name: "mixed project React + Go — frontend check wins first",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{"React"},
+				Languages: []detect.LanguageInfo{
+					{Name: "Go", Percentage: 60},
+					{Name: "JavaScript", Percentage: 40},
+				},
+			},
+			want: AdviserTierFrontend,
+		},
+		{
+			name:    "nil profile",
+			profile: nil,
+			want:    "",
+		},
+		{
+			name:    "empty profile no frameworks no languages",
+			profile: &detect.ProjectProfile{},
+			want:    "",
+		},
+		{
+			name: "unknown language no frontend frameworks",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{},
+				Languages:  []detect.LanguageInfo{{Name: "COBOL", Percentage: 100}},
+			},
+			want: "",
+		},
+		{
+			name: "multiple languages backend primary wins",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{},
+				Languages: []detect.LanguageInfo{
+					{Name: "Go", Percentage: 70},
+					{Name: "Shell", Percentage: 30},
+				},
+			},
+			want: AdviserTierBackend,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectProjectTier(tt.profile)
+			if got != tt.want {
+				t.Errorf("detectProjectTier() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterAdvisersByProfile(t *testing.T) {
+	frontendProfile := &detect.ProjectProfile{
+		Frameworks: []string{"React"},
+		Languages:  []detect.LanguageInfo{{Name: "TypeScript", Percentage: 90}},
+	}
+	backendProfile := &detect.ProjectProfile{
+		Frameworks: []string{},
+		Languages:  []detect.LanguageInfo{{Name: "Go", Percentage: 95}},
+	}
+
+	tests := []struct {
+		name         string
+		profile      *detect.ProjectProfile
+		advisers     []string
+		wantContains []string
+		wantExcludes []string
+	}{
+		{
+			name:         "frontend profile includes frontend and universal advisers",
+			profile:      frontendProfile,
+			advisers:     []string{"component-adviser", "api-first-adviser", "unit-test-adviser"},
+			wantContains: []string{"component-adviser", "unit-test-adviser"},
+			wantExcludes: []string{"api-first-adviser"},
+		},
+		{
+			name:         "frontend profile excludes all backend advisers",
+			profile:      frontendProfile,
+			advisers:     []string{"architect-adviser", "integration-test-adviser", "frontend-test-adviser", "web-accessibility-adviser"},
+			wantContains: []string{"frontend-test-adviser", "web-accessibility-adviser"},
+			wantExcludes: []string{"architect-adviser", "integration-test-adviser"},
+		},
+		{
+			name:         "backend profile includes backend and universal advisers",
+			profile:      backendProfile,
+			advisers:     []string{"architect-adviser", "frontend-test-adviser", "unit-test-adviser"},
+			wantContains: []string{"architect-adviser", "unit-test-adviser"},
+			wantExcludes: []string{"frontend-test-adviser"},
+		},
+		{
+			name:         "backend profile excludes all frontend advisers",
+			profile:      backendProfile,
+			advisers:     []string{"component-adviser", "web-accessibility-adviser", "api-first-adviser", "integration-test-adviser"},
+			wantContains: []string{"api-first-adviser", "integration-test-adviser"},
+			wantExcludes: []string{"component-adviser", "web-accessibility-adviser"},
+		},
+		{
+			name: "unknown profile returns all advisers unchanged",
+			profile: &detect.ProjectProfile{
+				Frameworks: []string{},
+				Languages:  []detect.LanguageInfo{{Name: "COBOL", Percentage: 100}},
+			},
+			advisers:     []string{"component-adviser", "api-first-adviser", "unit-test-adviser"},
+			wantContains: []string{"component-adviser", "api-first-adviser", "unit-test-adviser"},
+			wantExcludes: []string{},
+		},
+		{
+			name:         "nil profile returns all advisers unchanged",
+			profile:      nil,
+			advisers:     []string{"component-adviser", "api-first-adviser", "unit-test-adviser"},
+			wantContains: []string{"component-adviser", "api-first-adviser", "unit-test-adviser"},
+			wantExcludes: []string{},
+		},
+		{
+			name:         "unknown adviser name always included as universal default",
+			profile:      frontendProfile,
+			advisers:     []string{"component-adviser", "some-unknown-adviser", "api-first-adviser"},
+			wantContains: []string{"component-adviser", "some-unknown-adviser"},
+			wantExcludes: []string{"api-first-adviser"},
+		},
+		{
+			name:         "empty adviser list returns empty slice",
+			profile:      frontendProfile,
+			advisers:     []string{},
+			wantContains: []string{},
+			wantExcludes: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterAdvisersByProfile(tt.profile, tt.advisers)
+
+			gotSet := make(map[string]bool, len(got))
+			for _, name := range got {
+				gotSet[name] = true
+			}
+
+			for _, want := range tt.wantContains {
+				if !gotSet[want] {
+					t.Errorf("FilterAdvisersByProfile() missing %q in result %v", want, got)
+				}
+			}
+
+			for _, excluded := range tt.wantExcludes {
+				if gotSet[excluded] {
+					t.Errorf("FilterAdvisersByProfile() should not contain %q in result %v", excluded, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -83,11 +83,6 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 		return RunResult{}, mapErr(err)
 	}
 
-	// Step 2 — SDD workflow info
-	if err := steps.ShowSDDInfoStep(); err != nil {
-		return RunResult{}, mapErr(err)
-	}
-
 	// Determine whether auto-recommend is enabled.
 	var installCfg model.InstallConfig
 	if m := loadExistingManifest(); m != nil {
@@ -95,11 +90,10 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 	}
 	recommendEnabled := autoRecommendEnabled(installCfg)
 
-	// Determine early if the workflow model selection step may be active.
-	// The step requires at least one qualifying agent (in ModelRoutingAgents)
-	// AND at least one workflow selected. We know the agent condition now; workflow
-	// selection is only known after Step 3. Set TotalSteps to 6 if qualifying
-	// agents exist so that Steps 2, 3, and 4 already show the correct total.
+	// Determine the step count BEFORE rendering any subsequent step header
+	// so the "N/Total" indicator is consistent across the whole wizard.
+	// The SDD model selection step (Step 3) is conditional on at least one
+	// qualifying agent (ModelRoutingAgents) being selected.
 	hasQualifyingAgent := false
 	for _, a := range agents {
 		if model.ModelRoutingAgents[a] {
@@ -112,6 +106,11 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 		baseSteps = 7
 	}
 	steps.TotalSteps = baseSteps
+
+	// Step 2 — SDD workflow info
+	if err := steps.ShowSDDInfoStep(); err != nil {
+		return RunResult{}, mapErr(err)
+	}
 
 	// Step 3 (conditional) — SDD model selection, before repositories
 	var workflowModels map[string]map[string]string

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"charm.land/huh/v2"
 	"gopkg.in/yaml.v3"
@@ -82,6 +83,11 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 		return RunResult{}, mapErr(err)
 	}
 
+	// Step 2 — SDD workflow info
+	if err := steps.ShowSDDInfoStep(); err != nil {
+		return RunResult{}, mapErr(err)
+	}
+
 	// Determine whether auto-recommend is enabled.
 	var installCfg model.InstallConfig
 	if m := loadExistingManifest(); m != nil {
@@ -92,9 +98,8 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 	// Determine early if the workflow model selection step may be active.
 	// The step requires at least one qualifying agent (in ModelRoutingAgents)
 	// AND at least one workflow selected. We know the agent condition now; workflow
-	// selection is only known after Step 3. Set TotalSteps to 5 if qualifying
-	// agents exist so that Steps 2 and 3 already show the correct total.
-	// After Step 3 we can confirm (or revert to 4) based on the actual selection.
+	// selection is only known after Step 3. Set TotalSteps to 6 if qualifying
+	// agents exist so that Steps 2, 3, and 4 already show the correct total.
 	hasQualifyingAgent := false
 	for _, a := range agents {
 		if model.ModelRoutingAgents[a] {
@@ -102,20 +107,40 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 			break
 		}
 	}
-	baseSteps := 5
+	baseSteps := 6
 	if hasQualifyingAgent {
-		baseSteps = 6
+		baseSteps = 7
 	}
 	steps.TotalSteps = baseSteps
 
-	// Step 2 — repository sources (alt screen, step indicator inside form)
+	// Step 3 (conditional) — SDD model selection, before repositories
+	var workflowModels map[string]map[string]string
+	if hasQualifyingAgent {
+		// Pre-load saved models from existing config for defaults.
+		var savedModels map[string]map[string]string
+		if existing != nil {
+			savedModels = existing.WorkflowModels
+		} else if savedManifest := loadExistingManifest(); savedManifest != nil {
+			savedModels = mergeWorkflowModels(savedManifest.Workflows)
+		}
+		// SDD workflow is always auto-selected — pass sddAutoSelected=true
+		// so model selection does not skip when no scan results exist yet.
+		var emptyManifests []model.WorkflowManifest
+		wm, err := steps.RunWorkflowModelSelection(agents, steps.SelectionResult{}, savedModels, emptyManifests, true)
+		if err != nil {
+			return RunResult{}, mapErr(err)
+		}
+		workflowModels = wm
+	}
+
+	// Step 4 — repository sources (alt screen, step indicator inside form)
 	// Pass catalog-detected sources; EnterRepositories merges them with knownSources.
 	sources, err := steps.EnterRepositories(catalogSources, preselectedSources)
 	if err != nil {
 		return RunResult{}, mapErr(err)
 	}
 
-	// Step 3 — scan + select (alt screen)
+	// Step 5 — scan + select (alt screen)
 	var selection steps.SelectionResult
 	var scanned []steps.ScanResult
 	var inputs []steps.ScannedRepoInput
@@ -182,6 +207,11 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 					catalog := recommend.StaticCatalog{}
 					if detected, fetchErr := catalog.FetchByProfile(profile); fetchErr == nil {
 						skillsShInput = steps.BuildSkillsShInput(detected)
+						// Filter adviser-kind skills to project-relevant subset.
+						// Only the skills.sh curated path is filtered; user-imported repos are unchanged.
+						if skillsShInput != nil {
+							skillsShInput.Skills = recommend.FilterAdvisersByProfile(profile, skillsShInput.Skills)
+						}
 					}
 				}
 			}
@@ -211,16 +241,18 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 		inputs = make([]steps.ScannedRepoInput, 0, len(scanned))
 		for _, r := range scanned {
 			if r.Error == nil {
+				sddWFs, restWFs := partitionSDDWorkflows(r.Workflows)
 				inputs = append(inputs, steps.ScannedRepoInput{
-					Source:            r.Source,
-					Skills:            r.Skills,
-					Rules:             r.Rules,
-					MCPs:              r.MCPs,
-					Workflows:         r.Workflows,
-					WorkflowManifests: r.WorkflowManifests,
-					Tools:             r.Tools,
-					Descs:             r.Descs,
-					MCPFiles:          r.MCPFiles,
+					Source:                r.Source,
+					Skills:                r.Skills,
+					Rules:                 r.Rules,
+					MCPs:                  r.MCPs,
+					Workflows:             restWFs,
+					WorkflowManifests:     r.WorkflowManifests,
+					Tools:                 r.Tools,
+					Descs:                 r.Descs,
+					MCPFiles:              r.MCPFiles,
+					AutoSelectedWorkflows: sddWFs,
 				})
 			}
 		}
@@ -279,52 +311,6 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 				break
 			}
 		}
-	}
-
-	// Collect workflow manifests from all scanned repos for the model selector.
-	var allWorkflowManifests []model.WorkflowManifest
-	for _, r := range scanned {
-		if r.Error == nil {
-			allWorkflowManifests = append(allWorkflowManifests, r.WorkflowManifests...)
-		}
-	}
-
-	// Now that selection is known, confirm whether the workflow model step will actually run.
-	if hasQualifyingAgent {
-		hasWorkflow := false
-		for _, repo := range selection.Repos {
-			if len(repo.SelectedWorkflows) > 0 {
-				hasWorkflow = true
-				break
-			}
-		}
-		if !hasWorkflow {
-			steps.TotalSteps = 5
-		}
-	}
-
-	// Step 4 (optional) — Workflow model selection
-	// Use saved models from ExistingConfig when provided; fall back to disk load.
-	var savedModels map[string]map[string]string
-	if existing != nil {
-		savedModels = existing.WorkflowModels
-	} else {
-		savedManifest := loadExistingManifest()
-		if savedManifest != nil {
-			savedModels = mergeWorkflowModels(savedManifest.Workflows)
-		}
-	}
-
-	workflowModels, err := steps.RunWorkflowModelSelection(agents, selection, savedModels, allWorkflowManifests)
-	if err != nil {
-		return RunResult{}, mapErr(err)
-	}
-
-	// Final confirmation: sync TotalSteps with the actual outcome.
-	if workflowModels != nil {
-		steps.TotalSteps = 6
-	} else {
-		steps.TotalSteps = 5
 	}
 
 	// Collect all tool definitions from scanned repos.
@@ -423,6 +409,21 @@ func mapErr(err error) error {
 		return huh.ErrUserAborted
 	}
 	return err
+}
+
+// partitionSDDWorkflows splits a workflow list into SDD workflows (auto-selected)
+// and non-SDD workflows (user-visible in TUI). The SDD set matches names that are
+// exactly "sdd", have prefix "sdd-", or have prefix "sdd " (case-insensitive).
+func partitionSDDWorkflows(workflows []string) (sdd []string, rest []string) {
+	for _, wf := range workflows {
+		lower := strings.ToLower(wf)
+		if lower == "sdd" || strings.HasPrefix(lower, "sdd-") || strings.HasPrefix(lower, "sdd ") {
+			sdd = append(sdd, wf)
+		} else {
+			rest = append(rest, wf)
+		}
+	}
+	return
 }
 
 // filterToolsBySelection filters tools by the user's category selections and

--- a/internal/tui/app_adviser_filter_test.go
+++ b/internal/tui/app_adviser_filter_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+package tui_test
+
+import (
+	"testing"
+
+	"github.com/davidarce/devrune/internal/detect"
+	"github.com/davidarce/devrune/internal/recommend"
+)
+
+// TestAdviserFilterInScanPath verifies the adviser filtering contract used by the
+// TUI scan path. Since tui.Run() requires a TTY, the integration contract is
+// tested through the public recommend.FilterAdvisersByProfile() function with
+// representative mock profiles.
+func TestAdviserFilterInScanPath(t *testing.T) {
+	allAdvisers := []string{
+		"component-adviser",
+		"web-accessibility-adviser",
+		"frontend-test-adviser",
+		"api-first-adviser",
+		"architect-adviser",
+		"integration-test-adviser",
+		"unit-test-adviser",
+	}
+
+	t.Run("frontend project only shows frontend and universal advisers", func(t *testing.T) {
+		profile := &detect.ProjectProfile{
+			Frameworks: []string{"React"},
+			Languages:  []detect.LanguageInfo{{Name: "TypeScript", Percentage: 90}},
+		}
+
+		got := recommend.FilterAdvisersByProfile(profile, allAdvisers)
+		gotSet := toSet(got)
+
+		mustContain := []string{"component-adviser", "unit-test-adviser"}
+		mustExclude := []string{"api-first-adviser"}
+
+		for _, name := range mustContain {
+			if !gotSet[name] {
+				t.Errorf("expected %q in filtered result %v", name, got)
+			}
+		}
+		for _, name := range mustExclude {
+			if gotSet[name] {
+				t.Errorf("did not expect %q in filtered result %v", name, got)
+			}
+		}
+	})
+
+	t.Run("backend project only shows backend and universal advisers", func(t *testing.T) {
+		profile := &detect.ProjectProfile{
+			Frameworks: []string{},
+			Languages:  []detect.LanguageInfo{{Name: "Go", Percentage: 95}},
+		}
+
+		got := recommend.FilterAdvisersByProfile(profile, allAdvisers)
+		gotSet := toSet(got)
+
+		mustContain := []string{"api-first-adviser", "architect-adviser", "integration-test-adviser", "unit-test-adviser"}
+		mustExclude := []string{"component-adviser", "web-accessibility-adviser", "frontend-test-adviser"}
+
+		for _, name := range mustContain {
+			if !gotSet[name] {
+				t.Errorf("expected %q in filtered result %v", name, got)
+			}
+		}
+		for _, name := range mustExclude {
+			if gotSet[name] {
+				t.Errorf("did not expect %q in filtered result %v", name, got)
+			}
+		}
+	})
+
+	t.Run("unknown project returns all advisers unchanged", func(t *testing.T) {
+		profile := &detect.ProjectProfile{
+			Frameworks: []string{},
+			Languages:  []detect.LanguageInfo{{Name: "COBOL", Percentage: 100}},
+		}
+
+		got := recommend.FilterAdvisersByProfile(profile, allAdvisers)
+		if len(got) != len(allAdvisers) {
+			t.Errorf("expected all %d advisers returned for unknown project, got %d: %v", len(allAdvisers), len(got), got)
+		}
+	})
+}
+
+func toSet(names []string) map[string]bool {
+	s := make(map[string]bool, len(names))
+	for _, n := range names {
+		s[n] = true
+	}
+	return s
+}

--- a/internal/tui/steps/recommend.go
+++ b/internal/tui/steps/recommend.go
@@ -27,7 +27,7 @@ func RunRecommendGate(recs []recommend.Recommendation, profile detect.ProjectPro
 
 	form := huh.NewForm(
 		huh.NewGroup(
-			stepHeader(4, TotalSteps, "AI Recommendations"),
+			stepHeader(5, TotalSteps, "AI Recommendations"),
 			huh.NewNote().
 				Title("").
 				Description(desc),

--- a/internal/tui/steps/repos.go
+++ b/internal/tui/steps/repos.go
@@ -70,7 +70,7 @@ func EnterRepositories(extraSources []string, preselected []string) ([]string, e
 
 	selectForm := huh.NewForm(
 		huh.NewGroup(
-			stepHeader(2, TotalSteps, "Repository sources"),
+			stepHeader(4, TotalSteps, "Repository sources"),
 			huh.NewMultiSelect[string]().
 				Title("Select repository catalogs").
 				Description(responsiveDescription(
@@ -128,7 +128,7 @@ func EnterRepositories(extraSources []string, preselected []string) ([]string, e
 
 			inputForm := huh.NewForm(
 				huh.NewGroup(
-					stepHeader(2, TotalSteps, "Repository sources"),
+					stepHeader(4, TotalSteps, "Repository sources"),
 					huh.NewInput().
 						Title(prompt).
 						Description(desc).

--- a/internal/tui/steps/sdd_info.go
+++ b/internal/tui/steps/sdd_info.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+package steps
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/huh/v2"
+
+	"github.com/davidarce/devrune/internal/tui/tuistyles"
+)
+
+// sddInfoFullContent is the full-width description shown on wide terminals.
+const sddInfoFullContent = `Your agent uses SDD (Spec-Driven Development).
+
+DevRune installs the SDD workflow to guide structured development:
+
+  ① Explore    — Discover codebase context before making changes
+  ② Plan       — Create a detailed implementation plan
+  ③ Implement  — Execute the plan in reviewable batches
+  ④ Review     — Verify against the plan before committing
+
+Your agent will evaluate each task and apply SDD automatically
+for new features and multi-file changes. Simple fixes skip SDD.`
+
+// sddInfoShortContent is the compact description shown on narrow terminals.
+const sddInfoShortContent = `Your agent uses SDD (Spec-Driven Development).
+4 phases: Explore → Plan → Implement → Review.
+Agent evaluates SDD before any code change.`
+
+// sddInfoContent returns the appropriate description string for the given
+// terminal width. Exposed for unit testing without a real TTY.
+func sddInfoContent(termWidth int) string {
+	return testableResponsiveDescription(sddInfoFullContent, sddInfoShortContent, termWidth)
+}
+
+// ShowSDDInfoStep renders the SDD workflow informational step.
+// Always shown as step 2 in the wizard sequence.
+// Returns huh.ErrUserAborted if the user presses Ctrl-C.
+func ShowSDDInfoStep() error {
+	content := responsiveDescription(sddInfoFullContent, sddInfoShortContent)
+
+	confirmed := true
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			stepHeader(2, TotalSteps, "SDD Workflow"),
+			huh.NewNote().
+				Title("SDD Workflow").
+				Description(content),
+			huh.NewConfirm().
+				Affirmative("Continue →").
+				Negative("").
+				Value(&confirmed),
+		),
+	).WithTheme(tuistyles.DevRuneThemeFunc).
+		WithViewHook(func(v tea.View) tea.View {
+			v.AltScreen = true
+			return v
+		})
+
+	return form.Run()
+}

--- a/internal/tui/steps/sdd_info_test.go
+++ b/internal/tui/steps/sdd_info_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+
+package steps
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSDDInfoContent verifies that sddInfoContent returns the correct description
+// based on terminal width relative to narrowWidthThreshold (70).
+func TestSDDInfoContent(t *testing.T) {
+	tests := []struct {
+		name          string
+		width         int
+		wantSubstring string
+		wantAbsent    string
+	}{
+		{
+			name:          "wide terminal (w=80) returns full content with all four phases",
+			width:         80,
+			wantSubstring: "Explore",
+		},
+		{
+			name:          "wide terminal (w=80) contains Plan phase",
+			width:         80,
+			wantSubstring: "Plan",
+		},
+		{
+			name:          "wide terminal (w=80) contains Implement phase",
+			width:         80,
+			wantSubstring: "Implement",
+		},
+		{
+			name:          "wide terminal (w=80) contains Review phase",
+			width:         80,
+			wantSubstring: "Review",
+		},
+		{
+			name:          "narrow terminal (w=60) returns short content with '4 phases'",
+			width:         60,
+			wantSubstring: "4 phases",
+		},
+		{
+			name:          "narrow terminal (w=60) short content does not contain numbered phase list",
+			width:         60,
+			wantAbsent:    "① Explore",
+		},
+		{
+			name:          "at threshold (w=70) returns full content (strictly less-than check)",
+			width:         70,
+			wantSubstring: "Explore",
+		},
+		{
+			name:          "one below threshold (w=69) returns short content",
+			width:         69,
+			wantSubstring: "4 phases",
+		},
+		{
+			name:          "very wide terminal (w=200) returns full content",
+			width:         200,
+			wantSubstring: "Implement",
+		},
+		{
+			name:          "minimum width (w=1) returns short content",
+			width:         1,
+			wantSubstring: "4 phases",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sddInfoContent(tc.width)
+
+			if tc.wantSubstring != "" && !strings.Contains(got, tc.wantSubstring) {
+				t.Errorf("sddInfoContent(%d) = %q; want it to contain %q", tc.width, got, tc.wantSubstring)
+			}
+
+			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
+				t.Errorf("sddInfoContent(%d) = %q; want it NOT to contain %q", tc.width, got, tc.wantAbsent)
+			}
+		})
+	}
+}
+
+// TestSDDInfoContentDistinctBranches verifies that wide and narrow terminals return
+// distinct content (not the same string).
+func TestSDDInfoContentDistinctBranches(t *testing.T) {
+	wide := sddInfoContent(80)
+	narrow := sddInfoContent(60)
+
+	if wide == narrow {
+		t.Error("sddInfoContent(80) and sddInfoContent(60) returned identical strings; expected distinct content for wide vs narrow terminals")
+	}
+}
+
+// TestSDDInfoContentFullHasFourPhases verifies the full content mentions all four
+// SDD phase names in a single call.
+func TestSDDInfoContentFullHasFourPhases(t *testing.T) {
+	content := sddInfoContent(80)
+
+	phases := []string{"Explore", "Plan", "Implement", "Review"}
+	for _, phase := range phases {
+		if !strings.Contains(content, phase) {
+			t.Errorf("sddInfoContent(80): full content missing phase %q", phase)
+		}
+	}
+}

--- a/internal/tui/steps/select.go
+++ b/internal/tui/steps/select.go
@@ -29,6 +29,10 @@ type ScannedRepoInput struct {
 	// (e.g. "Spring Boot", "Java"). Headers are not selectable and do not count
 	// toward selected totals. Only applies to the Skills category.
 	SkillHeaders map[string]bool
+	// AutoSelectedWorkflows lists workflow names that are automatically included
+	// in the result without being shown in the TUI selection UI.
+	// Used for the SDD workflow from devrune-starter-catalog.
+	AutoSelectedWorkflows []string
 }
 
 // SelectionResult holds the final user selection after the select step.
@@ -90,9 +94,10 @@ func (c *CategorySelection) selectableCount() int {
 
 // RepoSelection holds the selection state for one repository.
 type RepoSelection struct {
-	Source     string
-	Categories [5]CategorySelection // Skills, Rules, MCPs, Workflows, Tools
-	MCPFiles   map[string]string    // MCP name → filename
+	Source       string
+	Categories   [5]CategorySelection // Skills, Rules, MCPs, Workflows, Tools
+	MCPFiles     map[string]string    // MCP name → filename
+	autoSelected []string             // SDD (and future) auto-selected workflow names
 }
 
 // ExpandedView tracks the expanded state for a category.
@@ -190,25 +195,15 @@ func NewSelectModel(repos []ScannedRepoInput) *SelectModel {
 				descs[td.Name] = td.Description
 			}
 		}
+		// Exclude auto-selected workflows from the visible TUI list.
+		visibleWorkflows := filterOutStrings(r.Workflows, r.AutoSelectedWorkflows)
+
 		categories := [5]CategorySelection{
 			buildCategoryWithDescsAndHeaders("Skills", r.Skills, descs, r.SkillHeaders),
 			buildCategoryWithDescs("Rules", r.Rules, descs),
 			buildCategoryWithDescs("MCPs", r.MCPs, descs),
-			buildCategoryWithDescs("Workflows", r.Workflows, descs),
+			buildCategoryWithDescs("Workflows", visibleWorkflows, descs),
 			buildCategoryWithDescs("Tools", toolNames, descs),
-		}
-
-		// Mark SDD workflow items with a "Recommended" badge and pre-select them.
-		wfCat := &categories[3]
-		for _, item := range wfCat.Items {
-			lower := strings.ToLower(item)
-			if lower == "sdd" || strings.HasPrefix(lower, "sdd-") || strings.HasPrefix(lower, "sdd ") {
-				wfCat.Badges[item] = "Recommended"
-				wfCat.Selected[item] = true
-				if !wfCat.IsOn {
-					wfCat.IsOn = true
-				}
-			}
 		}
 
 		// Pre-select engram MCP (important for SDD workflow).
@@ -224,9 +219,10 @@ func NewSelectModel(repos []ScannedRepoInput) *SelectModel {
 		}
 
 		selections[i] = RepoSelection{
-			Source:     r.Source,
-			Categories: categories,
-			MCPFiles:   r.MCPFiles,
+			Source:       r.Source,
+			Categories:   categories,
+			MCPFiles:     r.MCPFiles,
+			autoSelected: r.AutoSelectedWorkflows,
 		}
 	}
 
@@ -375,6 +371,8 @@ func (m *SelectModel) Result() SelectionResult {
 				}
 			}
 		}
+		// Append auto-selected workflows unconditionally (not user-visible).
+		rr.SelectedWorkflows = append(rr.SelectedWorkflows, repo.autoSelected...)
 
 		tools := repo.Categories[4]
 		if tools.IsOn {
@@ -661,9 +659,6 @@ func (m *SelectModel) renderCollapsed() string {
 	sb.WriteString("\n")
 	sb.WriteString("  ")
 	sb.WriteString(tuistyles.StyleInfo.Render("↑/↓ navigate  Space toggle  Enter expand/confirm"))
-	sb.WriteString("\n")
-	sb.WriteString("  ")
-	sb.WriteString(tuistyles.StyleSuccess.Render("★ SDD workflow is recommended for spec-driven development"))
 	sb.WriteString("\n\n")
 
 	for ri, repo := range m.repos {
@@ -910,6 +905,25 @@ func (m *SelectModel) renderExpanded() string {
 	sb.WriteString("\n")
 
 	return sb.String()
+}
+
+// filterOutStrings returns items with any name in exclude removed.
+// Comparison is case-sensitive and order-preserving.
+func filterOutStrings(items, exclude []string) []string {
+	if len(exclude) == 0 {
+		return items
+	}
+	excludeSet := make(map[string]bool, len(exclude))
+	for _, e := range exclude {
+		excludeSet[e] = true
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if !excludeSet[item] {
+			result = append(result, item)
+		}
+	}
+	return result
 }
 
 // applyFilter filters items by a substring match (case-insensitive).

--- a/internal/tui/steps/select_sdd_test.go
+++ b/internal/tui/steps/select_sdd_test.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+
+package steps
+
+import (
+	"slices"
+	"testing"
+)
+
+// ── filterOutStrings ──────────────────────────────────────────────────────────
+
+func TestFilterOutStrings_SDDPartitioning(t *testing.T) {
+	tests := []struct {
+		name    string
+		items   []string
+		exclude []string
+		want    []string
+	}{
+		{
+			name:    "removes exact match",
+			items:   []string{"sdd", "react-patterns"},
+			exclude: []string{"sdd"},
+			want:    []string{"react-patterns"},
+		},
+		{
+			name:    "removes sdd-orchestrator",
+			items:   []string{"sdd-orchestrator", "react-patterns"},
+			exclude: []string{"sdd-orchestrator"},
+			want:    []string{"react-patterns"},
+		},
+		{
+			name:    "case-sensitive: SDD Workflow kept if exclude uses lowercase",
+			items:   []string{"SDD Workflow", "react-patterns"},
+			exclude: []string{"sdd workflow"},
+			want:    []string{"SDD Workflow", "react-patterns"},
+		},
+		{
+			name:    "case-sensitive: SDD Workflow removed when casing matches",
+			items:   []string{"SDD Workflow", "react-patterns"},
+			exclude: []string{"SDD Workflow"},
+			want:    []string{"react-patterns"},
+		},
+		{
+			name:    "empty input produces empty result",
+			items:   nil,
+			exclude: []string{"sdd"},
+			want:    []string{},
+		},
+		{
+			name:    "empty exclude returns original slice",
+			items:   []string{"sdd", "react-patterns"},
+			exclude: nil,
+			want:    []string{"sdd", "react-patterns"},
+		},
+		{
+			name:    "react-patterns kept when only sdd excluded",
+			items:   []string{"sdd", "react-patterns"},
+			exclude: []string{"sdd"},
+			want:    []string{"react-patterns"},
+		},
+		{
+			name:    "both empty produces empty result",
+			items:   nil,
+			exclude: nil,
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterOutStrings(tc.items, tc.exclude)
+			// Nil and empty-slice are treated as equivalent here.
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("filterOutStrings(%v, %v) = %v; want %v",
+					tc.items, tc.exclude, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── NewSelectModel: auto-selected workflows not shown in TUI ──────────────────
+
+func TestAutoSelectedWorkflowsNotInTUI(t *testing.T) {
+	input := ScannedRepoInput{
+		Source:                "test-catalog",
+		Workflows:             []string{"sdd-orchestrator", "react-patterns"},
+		AutoSelectedWorkflows: []string{"sdd-orchestrator"},
+	}
+
+	m := NewSelectModel([]ScannedRepoInput{input})
+
+	wfCat := m.repos[0].Categories[3] // index 3 = Workflows
+
+	for _, item := range wfCat.Items {
+		if item == "sdd-orchestrator" {
+			t.Error("Workflows category Items should NOT contain 'sdd-orchestrator' (auto-selected)")
+		}
+	}
+
+	found := false
+	for _, item := range wfCat.Items {
+		if item == "react-patterns" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Workflows category Items SHOULD contain 'react-patterns'")
+	}
+}
+
+func TestAutoSelectedWorkflowsStoredInRepo(t *testing.T) {
+	input := ScannedRepoInput{
+		Source:                "test-catalog",
+		Workflows:             []string{"sdd-orchestrator", "react-patterns"},
+		AutoSelectedWorkflows: []string{"sdd-orchestrator"},
+	}
+
+	m := NewSelectModel([]ScannedRepoInput{input})
+
+	repo := m.repos[0]
+	if len(repo.autoSelected) != 1 || repo.autoSelected[0] != "sdd-orchestrator" {
+		t.Errorf("autoSelected: want [sdd-orchestrator], got %v", repo.autoSelected)
+	}
+}
+
+// ── Result: auto-selected workflows injected into SelectedWorkflows ───────────
+
+func TestAutoSelectedWorkflowsInResult(t *testing.T) {
+	input := ScannedRepoInput{
+		Source:                "test-catalog",
+		Workflows:             []string{"sdd-orchestrator", "react-patterns"},
+		AutoSelectedWorkflows: []string{"sdd-orchestrator"},
+	}
+
+	m := NewSelectModel([]ScannedRepoInput{input})
+
+	// Select "react-patterns" manually so it also appears in the result.
+	wfCat := &m.repos[0].Categories[3]
+	wfCat.IsOn = true
+	for _, item := range wfCat.Items {
+		wfCat.Selected[item] = true
+	}
+
+	result := m.Result()
+
+	if len(result.Repos) == 0 {
+		t.Fatal("Result has no repos")
+	}
+
+	selected := result.Repos[0].SelectedWorkflows
+
+	containsSDD := slices.Contains(selected, "sdd-orchestrator")
+	if !containsSDD {
+		t.Errorf("SelectedWorkflows should contain 'sdd-orchestrator'; got %v", selected)
+	}
+
+	containsReact := slices.Contains(selected, "react-patterns")
+	if !containsReact {
+		t.Errorf("SelectedWorkflows should contain 'react-patterns'; got %v", selected)
+	}
+}
+
+func TestAutoSelectedWorkflowsInResultEvenWhenWFCategoryOff(t *testing.T) {
+	// Even if the Workflows category toggle is OFF (user deselected all),
+	// auto-selected workflows must still appear in the result.
+	input := ScannedRepoInput{
+		Source:                "test-catalog",
+		Workflows:             []string{"sdd-orchestrator", "react-patterns"},
+		AutoSelectedWorkflows: []string{"sdd-orchestrator"},
+	}
+
+	m := NewSelectModel([]ScannedRepoInput{input})
+
+	// Explicitly leave category IsOn = false (default from buildCategoryWithDescs).
+	wfCat := &m.repos[0].Categories[3]
+	wfCat.IsOn = false
+
+	result := m.Result()
+	selected := result.Repos[0].SelectedWorkflows
+
+	containsSDD := slices.Contains(selected, "sdd-orchestrator")
+	if !containsSDD {
+		t.Errorf("SelectedWorkflows must contain auto-selected 'sdd-orchestrator' even when category is off; got %v", selected)
+	}
+}
+
+func TestNoAutoSelectedWorkflowsProducesEmptyAutoSlice(t *testing.T) {
+	input := ScannedRepoInput{
+		Source:    "test-catalog",
+		Workflows: []string{"react-patterns"},
+		// AutoSelectedWorkflows is nil
+	}
+
+	m := NewSelectModel([]ScannedRepoInput{input})
+
+	if len(m.repos[0].autoSelected) != 0 {
+		t.Errorf("autoSelected: want empty, got %v", m.repos[0].autoSelected)
+	}
+}

--- a/internal/tui/steps/steps.go
+++ b/internal/tui/steps/steps.go
@@ -28,8 +28,8 @@ func ansiStyle(color string, bold bool) lipgloss.Style {
 }
 
 // TotalSteps controls the total step count shown in the wizard step indicator.
-// app.go sets this to 6 when the SDD model selection step is active, 5 otherwise.
-var TotalSteps = 5
+// app.go sets this to 7 when the SDD model selection step is active, 6 otherwise.
+var TotalSteps = 6
 
 const (
 	// narrowWidthThreshold is the terminal width below which compact/short variants are used.

--- a/internal/tui/steps/workflow_models.go
+++ b/internal/tui/steps/workflow_models.go
@@ -766,6 +766,18 @@ func RunWorkflowModelSelection(
 
 	// Get subagent roles that define a model.
 	roles := subagentRoles(workflows)
+	// Fresh install with SDD auto-selected but no workflow manifests loaded yet
+	// (model selection runs before the scan step): synthesize the canonical SDD
+	// subagent role list so the form always shows on first install.
+	if len(roles) == 0 && sddAutoSelected && len(savedModels) == 0 {
+		for _, roleName := range []string{"sdd-explorer", "sdd-planner", "sdd-implementer", "sdd-reviewer", "sdd-adviser"} {
+			roles = append(roles, model.WorkflowRole{
+				Name:  roleName,
+				Kind:  "subagent",
+				Model: roleName,
+			})
+		}
+	}
 	// When no roles are found from workflow manifests but savedModels has entries,
 	// synthesize roles from the saved model keys so the form always shows and
 	// lets the user review or change their previous selections.

--- a/internal/tui/steps/workflow_models.go
+++ b/internal/tui/steps/workflow_models.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"sort"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -420,7 +421,7 @@ func (m modelSelectorModel) View() tea.View {
 	var b strings.Builder
 
 	// Header: banner + step indicator.
-	b.WriteString(stepHeaderString(4, TotalSteps, m.stepLabel))
+	b.WriteString(stepHeaderString(3, TotalSteps, m.stepLabel))
 	b.WriteString("\n\n")
 
 	// Compute usable content width (terminal width minus left indent of 2).
@@ -736,6 +737,7 @@ func RunWorkflowModelSelection(
 	selection SelectionResult,
 	savedModels map[string]map[string]string,
 	workflows []model.WorkflowManifest,
+	sddAutoSelected bool,
 ) (map[string]map[string]string, error) {
 	// Check qualifying agents.
 	var qualifyingAgents []string
@@ -748,12 +750,14 @@ func RunWorkflowModelSelection(
 		return nil, nil
 	}
 
-	// Check that at least one workflow is selected.
-	hasWorkflow := false
-	for _, repo := range selection.Repos {
-		if len(repo.SelectedWorkflows) > 0 {
-			hasWorkflow = true
-			break
+	// Check that at least one workflow is selected (or SDD is auto-selected).
+	hasWorkflow := sddAutoSelected
+	if !hasWorkflow {
+		for _, repo := range selection.Repos {
+			if len(repo.SelectedWorkflows) > 0 {
+				hasWorkflow = true
+				break
+			}
 		}
 	}
 	if !hasWorkflow {
@@ -766,18 +770,28 @@ func RunWorkflowModelSelection(
 	// synthesize roles from the saved model keys so the form always shows and
 	// lets the user review or change their previous selections.
 	if len(roles) == 0 && len(savedModels) > 0 {
+		// Collect unique role names from all agents' saved models.
 		seen := make(map[string]bool)
+		var roleNames []string
 		for _, roleMap := range savedModels {
 			for roleName := range roleMap {
 				if !seen[roleName] {
 					seen[roleName] = true
-					roles = append(roles, model.WorkflowRole{
-						Name:  roleName,
-						Kind:  "subagent",
-						Model: roleName,
-					})
+					roleNames = append(roleNames, roleName)
 				}
 			}
+		}
+		// Sort by canonical SDD phase order (explore → plan → implement → review → adviser),
+		// with unknown roles appended alphabetically at the end.
+		sort.SliceStable(roleNames, func(i, j int) bool {
+			return canonicalPhaseIndex(roleNames[i]) < canonicalPhaseIndex(roleNames[j])
+		})
+		for _, roleName := range roleNames {
+			roles = append(roles, model.WorkflowRole{
+				Name:  roleName,
+				Kind:  "subagent",
+				Model: roleName,
+			})
 		}
 	}
 	if len(roles) == 0 {
@@ -875,6 +889,27 @@ func phaseFromRole(roleKey string) string {
 		return strings.ToUpper(roleKey[:1]) + roleKey[1:]
 	}
 	return roleKey
+}
+
+// canonicalPhaseIndex returns a sort key for SDD role names.
+// Canonical order: explore(0) → plan(1) → implement(2) → review(3) → adviser(4).
+// Unknown roles get index 99 (sorted alphabetically among themselves).
+func canonicalPhaseIndex(roleName string) int {
+	phase := strings.ToLower(phaseFromRole(roleName))
+	switch phase {
+	case "explore", "explorer":
+		return 0
+	case "plan", "planner":
+		return 1
+	case "implement", "implementer":
+		return 2
+	case "review", "reviewer":
+		return 3
+	case "adviser", "advisor":
+		return 4
+	default:
+		return 99
+	}
 }
 
 // groupRolesByPhase groups roles by their phase (from phaseFromRole).

--- a/internal/tui/steps/workflow_models_test.go
+++ b/internal/tui/steps/workflow_models_test.go
@@ -77,7 +77,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoAgentSupportsModelRouting(t *
 		},
 	}
 
-	result, err := RunWorkflowModelSelection(agents, selection, nil, nil)
+	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoWorkflowsSelected(t *testing.
 		},
 	}
 
-	result, err := RunWorkflowModelSelection(agents, selection, nil, nil)
+	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoRepos(t *testing.T) {
 		Repos: []RepoSelectionResult{},
 	}
 
-	result, err := RunWorkflowModelSelection(agents, selection, nil, nil)
+	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoRolesHaveModel(t *testing.T) 
 		},
 	}
 
-	result, err := RunWorkflowModelSelection(agents, selection, nil, workflows)
+	result, err := RunWorkflowModelSelection(agents, selection, nil, workflows, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Add dedicated SDD info step (step 2) explaining the 4 phases: Explore → Plan → Implement → Review
- Move model selection to step 3, right after SDD info, for better logical grouping
- Auto-select SDD workflow — hidden from TUI selection, always included in manifest
- Smart adviser filtering by project type (frontend/backend) using existing `detect.Analyze()` ProjectProfile
- Canonical phase ordering in model selection (Explorer → Planner → Implementer → Reviewer → Adviser)

Closes #36

## Test Plan
- [x] Unit tests for adviser filter (19 tier + filter cases)
- [x] Unit tests for SDD info step (12 responsive content cases)
- [x] Unit tests for SDD auto-selection (6 partition + injection cases)
- [x] Integration test for adviser filter wiring (3 project type scenarios)
- [x] All existing tests pass (`go test ./...`)
- [x] Lint passes (`golangci-lint run ./...`)
- [x] Manual testing: `devrune init` on libraries workspace with claude + opencode agents

🤖 Generated with [Claude Code](https://claude.ai/claude-code)