### PR TITLE
feat(tui): add Configure role models menu option for SDD agents

### DIFF
--- a/internal/cli/configure_models.go
+++ b/internal/cli/configure_models.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/davidarce/devrune/internal/model"
+	"github.com/davidarce/devrune/internal/parse"
+	"github.com/davidarce/devrune/internal/tui/steps"
+)
+
+// errConfigureCancelled is returned by runConfigureModelsFromMenu when the user
+// cancels the model selector. Callers (e.g. RunMenu) treat this as a silent
+// no-op and loop back to the menu without showing any message.
+var errConfigureCancelled = errors.New("configure models cancelled")
+
+// updateManifestWorkflowModels writes newModels (map[agent]map[role]string) back into
+// all workflow entries in the manifest. Each workflow entry's Roles map is updated
+// for every agent/role present in newModels. Entries with no matching roles are left untouched.
+// If newModels is nil or empty, existing roles are cleared.
+func updateManifestWorkflowModels(manifest *model.UserManifest, newModels map[string]map[string]string) {
+	if len(manifest.Workflows) == 0 {
+		return
+	}
+	for name, entry := range manifest.Workflows {
+		if len(newModels) == 0 {
+			entry.Roles = nil
+			manifest.Workflows[name] = entry
+			continue
+		}
+		if entry.Roles == nil {
+			entry.Roles = make(map[string]map[string]string)
+		}
+		for agent, roleMap := range newModels {
+			if entry.Roles[agent] == nil {
+				entry.Roles[agent] = make(map[string]string)
+			}
+			for role, val := range roleMap {
+				entry.Roles[agent][role] = val
+			}
+		}
+		manifest.Workflows[name] = entry
+	}
+}
+
+// runConfigureModelsFromMenu runs the standalone model reconfiguration flow from the TUI menu.
+// It reads the current manifest, presents the model selector (step 1 of 1), writes the updated
+// manifest on confirm, then runs sync+install. On cancel, the manifest is not modified.
+// NOTE: steps.TotalSteps must be set to 1 before calling RunWorkflowModelSelection in standalone mode.
+func runConfigureModelsFromMenu(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	wd := workingDir(cmd)
+	verbose := isVerbose(cmd)
+	out := cmd.OutOrStdout()
+	manifestPath := filepath.Join(wd, "devrune.yaml")
+
+	// 1. Read and parse manifest.
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("devrune.yaml not found — run Setup first")
+	}
+	manifest, err := parse.ParseManifest(manifestData)
+	if err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+
+	// 2. Collect qualifying agent names.
+	var agentNames []string
+	for _, a := range manifest.Agents {
+		if model.ModelRoutingAgents[a.Name] {
+			agentNames = append(agentNames, a.Name)
+		}
+	}
+	if len(agentNames) == 0 {
+		return fmt.Errorf("no model-routing agents configured — run Setup first")
+	}
+
+	// 3. Load saved models from existing manifest.
+	savedModels := mergeWorkflowModels(manifest.Workflows)
+
+	// 4. Run model selector (standalone: step 1 of 1).
+	// NOTE: TotalSteps is a package-level variable; safe for single-threaded CLI use.
+	steps.TotalSteps = 1
+	newModels, err := steps.RunWorkflowModelSelection(
+		agentNames,
+		steps.SelectionResult{},
+		savedModels,
+		nil,  // no workflow manifests in standalone mode
+		true, // sddAutoSelected
+		1,    // stepNum
+	)
+	if err != nil {
+		if errors.Is(err, steps.ErrModelSelectionCancelled) {
+			// User cancelled — return sentinel so RunMenu skips the message.
+			return errConfigureCancelled
+		}
+		return err
+	}
+	if newModels == nil {
+		// No changes made (all inherit — treat as cancel/no-op).
+		return errConfigureCancelled
+	}
+
+	// 5. Update manifest with new model selections.
+	updateManifestWorkflowModels(&manifest, newModels)
+
+	// 6. Serialize and write manifest.
+	data, err := parse.SerializeManifest(manifest)
+	if err != nil {
+		return fmt.Errorf("serialize manifest: %w", err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		return fmt.Errorf("write manifest: %w", err)
+	}
+
+	// 7. Sync catalogs, then resolve + install.
+	_ = syncCatalogs(manifest, manifestPath)
+	lockPath := filepath.Join(wd, "devrune.lock")
+	if err := steps.RunInstallSpinner(
+		func() error {
+			_, resolveErr := RunResolve(ctx, wd, manifestPath, verbose, nopWriter{})
+			return resolveErr
+		},
+		func() error {
+			return RunInstall(ctx, wd, lockPath, manifest, verbose, nopWriter{})
+		},
+	); err != nil {
+		return fmt.Errorf("sync: %w", err)
+	}
+
+	_ = out // reserved for future verbose output
+	return nil
+}

--- a/internal/cli/configure_models_test.go
+++ b/internal/cli/configure_models_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/davidarce/devrune/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// Tests for updateManifestWorkflowModels
+// ---------------------------------------------------------------------------
+
+func TestUpdateManifestWorkflowModels_EmptyManifest_NoOp(t *testing.T) {
+	manifest := model.UserManifest{}
+	// Should not panic and manifest stays empty.
+	updateManifestWorkflowModels(&manifest, map[string]map[string]string{
+		"claude": {"sdd-explorer": "claude-sonnet-4-5"},
+	})
+	if len(manifest.Workflows) != 0 {
+		t.Errorf("expected empty workflows, got %d entries", len(manifest.Workflows))
+	}
+}
+
+func TestUpdateManifestWorkflowModels_SingleWorkflow_UpdatesRoles(t *testing.T) {
+	manifest := model.UserManifest{
+		Workflows: map[string]model.WorkflowEntry{
+			"sdd": {},
+		},
+	}
+	newModels := map[string]map[string]string{
+		"claude": {"sdd-explorer": "claude-sonnet-4-5", "sdd-planner": "claude-opus-4-5"},
+	}
+	updateManifestWorkflowModels(&manifest, newModels)
+
+	entry := manifest.Workflows["sdd"]
+	if entry.Roles == nil {
+		t.Fatal("expected roles to be set, got nil")
+	}
+	if entry.Roles["claude"]["sdd-explorer"] != "claude-sonnet-4-5" {
+		t.Errorf("sdd-explorer = %q, want %q", entry.Roles["claude"]["sdd-explorer"], "claude-sonnet-4-5")
+	}
+	if entry.Roles["claude"]["sdd-planner"] != "claude-opus-4-5" {
+		t.Errorf("sdd-planner = %q, want %q", entry.Roles["claude"]["sdd-planner"], "claude-opus-4-5")
+	}
+}
+
+func TestUpdateManifestWorkflowModels_NilNewModels_ClearsRoles(t *testing.T) {
+	manifest := model.UserManifest{
+		Workflows: map[string]model.WorkflowEntry{
+			"sdd": {
+				Roles: map[string]map[string]string{
+					"claude": {"sdd-explorer": "claude-sonnet-4-5"},
+				},
+			},
+		},
+	}
+	updateManifestWorkflowModels(&manifest, nil)
+
+	entry := manifest.Workflows["sdd"]
+	if entry.Roles != nil {
+		t.Errorf("expected nil roles after clearing, got %v", entry.Roles)
+	}
+}
+
+func TestUpdateManifestWorkflowModels_MultipleWorkflows_AllUpdated(t *testing.T) {
+	manifest := model.UserManifest{
+		Workflows: map[string]model.WorkflowEntry{
+			"sdd":  {},
+			"cicd": {},
+		},
+	}
+	newModels := map[string]map[string]string{
+		"claude": {"sdd-explorer": "claude-sonnet-4-5"},
+	}
+	updateManifestWorkflowModels(&manifest, newModels)
+
+	for name, entry := range manifest.Workflows {
+		if entry.Roles == nil {
+			t.Errorf("workflow %q: expected roles to be set, got nil", name)
+			continue
+		}
+		if entry.Roles["claude"]["sdd-explorer"] != "claude-sonnet-4-5" {
+			t.Errorf("workflow %q: sdd-explorer = %q, want %q",
+				name, entry.Roles["claude"]["sdd-explorer"], "claude-sonnet-4-5")
+		}
+	}
+}

--- a/internal/cli/menu.go
+++ b/internal/cli/menu.go
@@ -25,13 +25,33 @@ import (
 type menuAction string
 
 const (
-	menuActionInit      menuAction = "init"
-	menuActionSync      menuAction = "sync"
-	menuActionStatus    menuAction = "status"
-	menuActionUpgrade   menuAction = "upgrade"
-	menuActionUninstall menuAction = "uninstall"
-	menuActionQuit      menuAction = "quit"
+	menuActionInit            menuAction = "init"
+	menuActionSync            menuAction = "sync"
+	menuActionStatus          menuAction = "status"
+	menuActionConfigureModels menuAction = "configure-models"
+	menuActionUpgrade         menuAction = "upgrade"
+	menuActionUninstall       menuAction = "uninstall"
+	menuActionQuit            menuAction = "quit"
 )
+
+// hasModelRoutingAgents reports whether any agent in devrune.yaml is a model-routing agent.
+// Returns false if the manifest cannot be read or contains no qualifying agents.
+func hasModelRoutingAgents(wd string) bool {
+	data, err := os.ReadFile(filepath.Join(wd, "devrune.yaml"))
+	if err != nil {
+		return false
+	}
+	m, err := parse.ParseManifest(data)
+	if err != nil {
+		return false
+	}
+	for _, a := range m.Agents {
+		if model.ModelRoutingAgents[a.Name] {
+			return true
+		}
+	}
+	return false
+}
 
 // RunMenu displays the interactive DevRune main menu in a loop.
 // After each action completes, the menu re-displays so the user can
@@ -41,19 +61,26 @@ func RunMenu(cmd *cobra.Command) error {
 	for {
 		var selected menuAction
 
+		menuOptions := []huh.Option[menuAction]{
+			huh.NewOption("Setup", menuActionInit),
+			huh.NewOption("Sync project", menuActionSync),
+		}
+		if hasModelRoutingAgents(workingDir(cmd)) {
+			menuOptions = append(menuOptions, huh.NewOption("Configure role models", menuActionConfigureModels))
+		}
+		menuOptions = append(menuOptions,
+			huh.NewOption("Status", menuActionStatus),
+			huh.NewOption("Upgrade DevRune", menuActionUpgrade),
+			huh.NewOption("Uninstall", menuActionUninstall),
+			huh.NewOption("Quit", menuActionQuit),
+		)
+
 		form := huh.NewForm(
 			huh.NewGroup(
 				steps.BannerNote(),
 				huh.NewSelect[menuAction]().
 					Title("What would you like to do?").
-					Options(
-						huh.NewOption("Setup", menuActionInit),
-						huh.NewOption("Sync project", menuActionSync),
-						huh.NewOption("Status", menuActionStatus),
-						huh.NewOption("Upgrade DevRune", menuActionUpgrade),
-						huh.NewOption("Uninstall", menuActionUninstall),
-						huh.NewOption("Quit", menuActionQuit),
-					).
+					Options(menuOptions...).
 					Value(&selected),
 			),
 		).WithTheme(tuistyles.DevRuneThemeFunc).
@@ -91,6 +118,16 @@ func RunMenu(cmd *cobra.Command) error {
 				_ = showMenuMessage(cmd, "Status Error", err.Error())
 			}
 			// Loop back to menu.
+
+		case menuActionConfigureModels:
+			if err := runConfigureModelsFromMenu(cmd); err == errConfigureCancelled {
+				// User cancelled — loop back silently, no message.
+			} else if err != nil {
+				_ = showMenuMessage(cmd, "Configure Models Failed", err.Error())
+			} else {
+				_ = showMenuMessage(cmd, "Models Updated", "Role models updated and synced successfully.")
+			}
+		// Loop back to menu.
 
 		case menuActionUpgrade:
 			// Upgrade: if user confirms, binary is replaced and we exit.

--- a/internal/cli/menu_test.go
+++ b/internal/cli/menu_test.go
@@ -3,6 +3,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -16,8 +18,10 @@ func TestMenuActionConstants(t *testing.T) {
 		{"init", menuActionInit, "init"},
 		{"sync", menuActionSync, "sync"},
 		{"status", menuActionStatus, "status"},
+		{"configure-models", menuActionConfigureModels, "configure-models"},
 		{"upgrade", menuActionUpgrade, "upgrade"},
 		{"uninstall", menuActionUninstall, "uninstall"},
+		{"quit", menuActionQuit, "quit"},
 	}
 
 	for _, tt := range tests {
@@ -29,17 +33,19 @@ func TestMenuActionConstants(t *testing.T) {
 	}
 }
 
-// TestMenuActionCount verifies there are exactly 5 menu actions defined.
+// TestMenuActionCount verifies there are exactly 7 menu actions defined.
 func TestMenuActionCount(t *testing.T) {
 	actions := []menuAction{
 		menuActionInit,
 		menuActionSync,
 		menuActionStatus,
+		menuActionConfigureModels,
 		menuActionUpgrade,
 		menuActionUninstall,
+		menuActionQuit,
 	}
 
-	const wantCount = 5
+	const wantCount = 7
 	if len(actions) != wantCount {
 		t.Errorf("menu action count = %d, want %d", len(actions), wantCount)
 	}
@@ -52,8 +58,10 @@ func TestMenuActionUniqueness(t *testing.T) {
 		menuActionInit,
 		menuActionSync,
 		menuActionStatus,
+		menuActionConfigureModels,
 		menuActionUpgrade,
 		menuActionUninstall,
+		menuActionQuit,
 	}
 
 	for _, a := range actions {
@@ -69,5 +77,69 @@ func TestMenuActionType(t *testing.T) {
 	var a menuAction = "custom"
 	if string(a) != "custom" {
 		t.Errorf("menuAction string conversion failed: got %q, want %q", string(a), "custom")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests for hasModelRoutingAgents
+// ---------------------------------------------------------------------------
+
+func TestHasModelRoutingAgents_ReturnsTrueForClaudeAgent(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `schemaVersion: devrune/v1
+agents:
+  - name: claude
+`
+	if err := os.WriteFile(filepath.Join(dir, "devrune.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !hasModelRoutingAgents(dir) {
+		t.Error("expected true for manifest with claude agent")
+	}
+}
+
+func TestHasModelRoutingAgents_ReturnsTrueForOpenCodeAgent(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `schemaVersion: devrune/v1
+agents:
+  - name: opencode
+`
+	if err := os.WriteFile(filepath.Join(dir, "devrune.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !hasModelRoutingAgents(dir) {
+		t.Error("expected true for manifest with opencode agent")
+	}
+}
+
+func TestHasModelRoutingAgents_ReturnsFalseForNonRoutingAgents(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `schemaVersion: devrune/v1
+agents:
+  - name: copilot
+  - name: factory
+`
+	if err := os.WriteFile(filepath.Join(dir, "devrune.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if hasModelRoutingAgents(dir) {
+		t.Error("expected false for manifest with no model-routing agents")
+	}
+}
+
+func TestHasModelRoutingAgents_ReturnsFalseWhenNoManifest(t *testing.T) {
+	dir := t.TempDir()
+	if hasModelRoutingAgents(dir) {
+		t.Error("expected false when devrune.yaml does not exist")
+	}
+}
+
+func TestHasModelRoutingAgents_ReturnsFalseForInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "devrune.yaml"), []byte(":::invalid yaml:::"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if hasModelRoutingAgents(dir) {
+		t.Error("expected false for invalid YAML manifest")
 	}
 }

--- a/internal/materialize/renderers/hooks.go
+++ b/internal/materialize/renderers/hooks.go
@@ -68,11 +68,7 @@ func copyHookScriptAssets(hookData map[string]interface{}, cachePath, workspaceR
 
 		// cleanPath is the destination-relative path (e.g. ".claude/hooks/script.sh").
 		// The source in the cache omits the agent workspace prefix (e.g. "hooks/script.sh").
-		srcRelative := cleanPath
-		wsPrefix := agentWorkspace + "/"
-		if strings.HasPrefix(srcRelative, wsPrefix) {
-			srcRelative = srcRelative[len(wsPrefix):]
-		}
+		srcRelative := strings.TrimPrefix(cleanPath, agentWorkspace+"/")
 
 		srcFile := filepath.Join(cachePath, srcRelative)
 		// workspaceRoot already includes the agent workspace (e.g. ".claude/"),
@@ -139,15 +135,15 @@ func copyFileWithMode(src, dst string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
 		return err
 	}
 	return out.Close()

--- a/internal/materialize/renderers/hooks.go
+++ b/internal/materialize/renderers/hooks.go
@@ -68,7 +68,11 @@ func copyHookScriptAssets(hookData map[string]interface{}, cachePath, workspaceR
 
 		// cleanPath is the destination-relative path (e.g. ".claude/hooks/script.sh").
 		// The source in the cache omits the agent workspace prefix (e.g. "hooks/script.sh").
-		srcRelative := strings.TrimPrefix(cleanPath, agentWorkspace+"/")
+		srcRelative := cleanPath
+		wsPrefix := agentWorkspace + "/"
+		if strings.HasPrefix(srcRelative, wsPrefix) {
+			srcRelative = srcRelative[len(wsPrefix):]
+		}
 
 		srcFile := filepath.Join(cachePath, srcRelative)
 		// workspaceRoot already includes the agent workspace (e.g. ".claude/"),
@@ -135,13 +139,13 @@ func copyFileWithMode(src, dst string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = in.Close() }()
+	defer in.Close()
 
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = out.Close() }()
+	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -35,7 +36,7 @@ type CacheStore interface {
 type Resolver struct {
 	fetcher    Fetcher
 	cache      CacheStore
-	baseDir    string // directory containing devrune.yaml
+	baseDir    string            // directory containing devrune.yaml
 	priorIndex map[string]string // CacheKey → content hash from prior lockfile
 }
 
@@ -342,6 +343,12 @@ func (r *Resolver) resolveWorkflow(ctx context.Context, wfSource string) (model.
 	var wfDir string
 
 	if dir, ok := r.cache.Get(hash); ok {
+		// If the source ref has a subpath (e.g. "//workflows/sdd"), resolve
+		// workflow.yaml relative to that subdirectory within the cached archive
+		// root rather than searching the entire package tree.
+		if sourceRef.Subpath != "" {
+			dir = filepath.Join(dir, filepath.FromSlash(sourceRef.Subpath))
+		}
 		wfManifest, wfDir, err = parseWorkflowFromDir(dir)
 		if err != nil {
 			return model.LockedWorkflow{}, fmt.Errorf("resolve: workflow %q: %w", wfSource, err)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -125,7 +125,7 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 		// SDD workflow is always auto-selected — pass sddAutoSelected=true
 		// so model selection does not skip when no scan results exist yet.
 		var emptyManifests []model.WorkflowManifest
-		wm, err := steps.RunWorkflowModelSelection(agents, steps.SelectionResult{}, savedModels, emptyManifests, true)
+		wm, err := steps.RunWorkflowModelSelection(agents, steps.SelectionResult{}, savedModels, emptyManifests, true, 3)
 		if err != nil {
 			return RunResult{}, mapErr(err)
 		}

--- a/internal/tui/steps/workflow_models.go
+++ b/internal/tui/steps/workflow_models.go
@@ -3,6 +3,7 @@
 package steps
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -20,6 +21,10 @@ import (
 	"github.com/davidarce/devrune/internal/tui/tuistyles"
 )
 
+// ErrModelSelectionCancelled is returned by RunWorkflowModelSelection when the user
+// cancels the model selector without confirming a selection.
+var ErrModelSelectionCancelled = errors.New("model selection cancelled")
+
 // workflowModelSelectHeight is the number of visible rows for each model Select field.
 // Set to show all options without scrolling (inherit sentinel + haiku + sonnet + opus = 4).
 const workflowModelSelectHeight = 7
@@ -28,7 +33,6 @@ const workflowModelSelectHeight = 7
 // groups in a grid layout without clipping. Below this threshold the layout
 // falls back to LayoutColumns(2) which paginates groups at a time.
 const workflowGridMinHeight = 35
-
 
 // colMinWidth is the minimum per-agent column width for the column layout.
 const colMinWidth = 20
@@ -72,14 +76,14 @@ type modelPickedMsg struct {
 // for a single agent card's model options. The form is rendered full-screen
 // using the same alt-screen approach as other steps.
 type huhSelectCommand struct {
-	options  []model.ModelOption
-	current  int
-	title    string
-	stdin    io.Reader
-	stdout   io.Writer
-	stderr   io.Writer
-	chosen   int
-	err      error
+	options []model.ModelOption
+	current int
+	title   string
+	stdin   io.Reader
+	stdout  io.Writer
+	stderr  io.Writer
+	chosen  int
+	err     error
 }
 
 func (c *huhSelectCommand) SetStdin(r io.Reader)  { c.stdin = r }
@@ -122,7 +126,6 @@ func (c *huhSelectCommand) Run() error {
 	c.chosen = chosen
 	return nil
 }
-
 
 // WorkflowModelLayout returns the appropriate huh Layout for the workflow model
 // selection form based on the number of roles and terminal height.
@@ -199,7 +202,7 @@ type phaseRow struct {
 type focusTarget int
 
 const (
-	focusCards   focusTarget = iota // navigating the card grid
+	focusCards  focusTarget = iota // navigating the card grid
 	focusButton                    // navigating the confirm/cancel buttons
 )
 
@@ -223,6 +226,7 @@ type modelSelectorModel struct {
 
 	// Header info.
 	stepLabel string
+	stepNum   int
 
 	// Result state.
 	confirmed bool
@@ -234,6 +238,7 @@ func newModelSelectorModel(
 	roles []model.WorkflowRole,
 	savedModels map[string]map[string]string,
 	stepLabel string,
+	stepNum int,
 ) modelSelectorModel {
 	phases, phaseGroups := groupRolesByPhase(roles)
 
@@ -280,6 +285,7 @@ func newModelSelectorModel(
 	return modelSelectorModel{
 		phases:    phaseRows,
 		stepLabel: stepLabel,
+		stepNum:   stepNum,
 		width:     w,
 		height:    h,
 	}
@@ -399,7 +405,6 @@ func (m modelSelectorModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-
 func (m *modelSelectorModel) clampAgent() {
 	if len(m.phases) == 0 {
 		return
@@ -421,7 +426,7 @@ func (m modelSelectorModel) View() tea.View {
 	var b strings.Builder
 
 	// Header: banner + step indicator.
-	b.WriteString(stepHeaderString(3, TotalSteps, m.stepLabel))
+	b.WriteString(stepHeaderString(m.stepNum, TotalSteps, m.stepLabel))
 	b.WriteString("\n\n")
 
 	// Compute usable content width (terminal width minus left indent of 2).
@@ -581,7 +586,7 @@ func (m modelSelectorModel) renderColumnHeaders(numAgents, contentWidth int) []s
 // with a dim │ separator between each agent column. Agent names are NOT repeated
 // here — they appear once in the column headers rendered by renderColumnHeaders.
 //
-//	  › sonnet ▾              │    claude-sonnet-4.6 ▾
+//	› sonnet ▾              │    claude-sonnet-4.6 ▾
 func (m modelSelectorModel) renderPhaseCardsColumns(pr phaseRow, phaseIdx, contentWidth, numAgents int) []string {
 	numCards := len(pr.cards)
 	if numCards == 0 {
@@ -650,8 +655,8 @@ func (m modelSelectorModel) renderPhaseCardsColumns(pr phaseRow, phaseIdx, conte
 // (stacked) layout: one agent per line pair, separated by a blank line.
 // Used when the terminal is too narrow for the column layout.
 //
-//	  claude: sonnet ▾
-//	  opencode: claude-sonnet-4.6 ▾
+//	claude: sonnet ▾
+//	opencode: claude-sonnet-4.6 ▾
 func (m modelSelectorModel) renderPhaseCardsSequential(pr phaseRow, phaseIdx, contentWidth int) []string {
 	if len(pr.cards) == 0 {
 		return nil
@@ -738,6 +743,7 @@ func RunWorkflowModelSelection(
 	savedModels map[string]map[string]string,
 	workflows []model.WorkflowManifest,
 	sddAutoSelected bool,
+	stepNum int,
 ) (map[string]map[string]string, error) {
 	// Check qualifying agents.
 	var qualifyingAgents []string
@@ -840,7 +846,7 @@ func RunWorkflowModelSelection(
 	}
 
 	// Create and run the custom bubbletea model.
-	mdl := newModelSelectorModel(agentConfigs, roles, savedModels, stepLabel)
+	mdl := newModelSelectorModel(agentConfigs, roles, savedModels, stepLabel, stepNum)
 	p := tea.NewProgram(mdl)
 	finalModel, err := p.Run()
 	if err != nil {
@@ -849,7 +855,7 @@ func RunWorkflowModelSelection(
 
 	final := finalModel.(modelSelectorModel)
 	if final.cancelled {
-		return nil, fmt.Errorf("model selection cancelled")
+		return nil, ErrModelSelectionCancelled
 	}
 
 	// Collect results: map[agentName]map[roleName]modelValue.

--- a/internal/tui/steps/workflow_models_test.go
+++ b/internal/tui/steps/workflow_models_test.go
@@ -77,7 +77,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoAgentSupportsModelRouting(t *
 		},
 	}
 
-	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false)
+	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false, 3)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoWorkflowsSelected(t *testing.
 		},
 	}
 
-	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false)
+	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false, 3)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoRepos(t *testing.T) {
 		Repos: []RepoSelectionResult{},
 	}
 
-	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false)
+	result, err := RunWorkflowModelSelection(agents, selection, nil, nil, false, 3)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoRolesHaveModel(t *testing.T) 
 		},
 	}
 
-	result, err := RunWorkflowModelSelection(agents, selection, nil, workflows, false)
+	result, err := RunWorkflowModelSelection(agents, selection, nil, workflows, false, 3)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes #41

Adds a **"Configure role models"** option to the DevRune TUI main menu, allowing users to reconfigure AI models for SDD agent roles (claude, opencode) without running a full Setup wizard.

## Changes

- **`workflow_models.go`** — Parameterized `RunWorkflowModelSelection` with `stepNum int` so it displays "Step 1 of 1" in standalone mode; added `ErrModelSelectionCancelled` sentinel
- **`app.go`** — Updated wizard caller to pass `stepNum=3`
- **`menu.go`** — New `menuActionConfigureModels` constant, `hasModelRoutingAgents` guard (hides option when no model-routing agents), dynamic menu builder, and switch case
- **`configure_models.go`** _(new)_ — Standalone handler: reads manifest, runs model selector, writes manifest, auto-runs resolve+install
- **`menu_test.go`** — Tests for `hasModelRoutingAgents` + updated action constant/count/uniqueness assertions
- **`configure_models_test.go`** _(new)_ — Tests for `updateManifestWorkflowModels`

## Behavior

| Scenario | Result |
|----------|--------|
| No model-routing agents in `devrune.yaml` | Option hidden from menu |
| `devrune.yaml` not found | Error: "run Setup first" |
| User cancels model selector | Silent no-op, returns to menu |
| User confirms selections | Manifest written → resolve+install → "Models Updated" message |

## Menu Order

```
  Setup
  Sync project
  Configure role models   ← new, placed next to Sync
  Status
  Upgrade DevRune
  Uninstall
  Quit
```

## Extensibility

The handler auto-discovers **all** workflows in the manifest with model-routing roles. Future workflows (beyond SDD) are included automatically — no new menu entries required.