### PR TITLE
fix(resolve): bypass cache shortcut for mutable HEAD refs

### DIFF
--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -77,12 +77,27 @@ func (r *Resolver) SetPriorLockfile(lf model.Lockfile) {
 // cachedDir checks if a remote source is already cached via the prior lockfile index.
 // Returns the cached directory path and content hash if found, or empty strings if
 // the source must be fetched from the network.
+//
+// Mutable refs bypass the cache so a `devrune sync` picks up upstream changes:
+// an empty ref (implicit HEAD) or the literal "HEAD" both track whatever the
+// default branch points at right now, so reusing a prior content hash would
+// silently hide new commits. Immutable refs (tags, full commit SHAs, explicitly
+// named branches) still reuse the cache — the user opted in by pinning.
 func (r *Resolver) cachedDir(sourceRef model.SourceRef) (dir, hash string, ok bool) {
 	if r.priorIndex == nil {
 		return "", "", false
 	}
 	// Local sources always re-fetch (content may change on disk).
 	if sourceRef.Scheme == model.SchemeLocal {
+		return "", "", false
+	}
+	// Mutable ref (HEAD) always re-fetches — the bug this guards against:
+	// first resolve cached the tarball, subsequent `devrune sync` runs saw
+	// the ref unchanged (still empty), the CacheKey matched the prior hash,
+	// and we reused the cache without ever re-contacting the remote. Upstream
+	// merges were invisible until the user deleted `~/Library/Caches/devrune/
+	// packages/<hash>/` by hand.
+	if isMutableRef(sourceRef.Ref) {
 		return "", "", false
 	}
 	priorHash, exists := r.priorIndex[sourceRef.CacheKey()]
@@ -93,6 +108,20 @@ func (r *Resolver) cachedDir(sourceRef model.SourceRef) (dir, hash string, ok bo
 		return d, priorHash, true
 	}
 	return "", "", false
+}
+
+// isMutableRef reports whether a SourceRef's ref component names a moving
+// target (HEAD) rather than a pinned revision.
+//
+// Only the empty ref and the literal "HEAD" are treated as mutable here.
+// Branch names like "main" or "develop" are technically mutable too, but the
+// user typed them explicitly — treating every named ref as mutable would
+// defeat the cache for tag-based pinning, which is the common immutable case.
+// A follow-up could compare the branch tip SHA via a HEAD API call to get
+// both safety AND cache reuse for explicit branch refs, but the reported bug
+// is purely about the `ref: ""` default so this minimal guard closes it.
+func isMutableRef(ref string) bool {
+	return ref == "" || ref == "HEAD"
 }
 
 // Resolve processes a UserManifest and produces a Lockfile.

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -508,3 +508,154 @@ func TestResolver_InvalidWorkflowSourceRef(t *testing.T) {
 		t.Fatal("Resolve() expected error for invalid workflow source, got nil")
 	}
 }
+
+// countingFetcher wraps mockFetcher to count how many times Fetch is called
+// per CacheKey. Used by the mutable-ref cache-bypass regression test to
+// distinguish a cache hit (no additional fetch) from a cache miss that
+// re-hits the network.
+type countingFetcher struct {
+	inner mockFetcher
+	calls map[string]int
+}
+
+func (f *countingFetcher) Fetch(ctx context.Context, ref model.SourceRef) ([]byte, error) {
+	if f.calls == nil {
+		f.calls = map[string]int{}
+	}
+	f.calls[ref.CacheKey()]++
+	return f.inner.Fetch(ctx, ref)
+}
+
+func (f *countingFetcher) Supports(scheme model.Scheme) bool { return f.inner.Supports(scheme) }
+
+// TestResolver_EmptyRefBypassesCache is the regression test for the silent
+// "sync doesn't pull upstream changes" bug reported against `devrune sync`.
+//
+// Scenario: the user pins a package with an empty ref (e.g.
+// `github:org/repo` without an `@ref` suffix), which resolves to the remote's
+// HEAD. On the first resolve the tarball is fetched, hashed, and cached. On
+// subsequent resolves, the prior lockfile carries that content hash under the
+// CacheKey `github:org/repo@` — if the resolver blindly trusts the CacheKey
+// mapping, upstream commits on the default branch are invisible because the
+// resolver never re-contacts the remote.
+//
+// The fix: empty-ref (and literal "HEAD") sources skip the cache shortcut,
+// forcing a fetch every resolve so the new content hash (and therefore the
+// new cached tree) lands in the updated lockfile. Pinned refs (tags, commit
+// SHAs, explicit branch names) are unaffected — they still reuse the cache.
+func TestResolver_EmptyRefBypassesCache(t *testing.T) {
+	t.Run("empty ref re-fetches even when prior lockfile has a hash", func(t *testing.T) {
+		archiveV1 := buildTarGz(t, "owner-repo-head-v1", map[string]string{
+			"skills/git-commit/SKILL.md": "# v1",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@": archiveV1,
+			}},
+		}
+		cache := newMockCacheStore(t)
+		r := NewResolver(f, cache, "")
+
+		// Seed a prior lockfile whose CacheKey matches an empty ref. If the
+		// resolver honours the cache shortcut for this (buggy) case it won't
+		// call Fetch; the counter proves it does.
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+					},
+					Hash: HashBytes(archiveV1),
+				},
+			},
+		})
+
+		manifest := buildMinimalManifest("github:owner/repo")
+		if _, err := r.Resolve(context.Background(), manifest); err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@"]; got != 1 {
+			t.Errorf("Fetch called %d times for empty-ref source, want 1 (cache shortcut must NOT apply for mutable HEAD)", got)
+		}
+	})
+
+	t.Run("pinned tag reuses cache", func(t *testing.T) {
+		archive := buildTarGz(t, "owner-repo-v100", map[string]string{
+			"skills/git-commit/SKILL.md": "# pinned",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@v1.0.0": archive,
+			}},
+		}
+		cache := newMockCacheStore(t)
+
+		// Prime the cache so the prior-lockfile shortcut can fire.
+		if _, err := cache.Store("github:owner/repo@v1.0.0", archive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+						Ref:    "v1.0.0",
+					},
+					Hash: HashBytes(archive),
+				},
+			},
+		})
+
+		manifest := buildMinimalManifest("github:owner/repo@v1.0.0")
+		if _, err := r.Resolve(context.Background(), manifest); err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@v1.0.0"]; got != 0 {
+			t.Errorf("Fetch called %d times for pinned tag, want 0 (cache shortcut must apply for immutable refs)", got)
+		}
+	})
+
+	t.Run("literal HEAD ref is treated as mutable", func(t *testing.T) {
+		archive := buildTarGz(t, "owner-repo-head-literal", map[string]string{
+			"skills/x/SKILL.md": "# head",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@HEAD": archive,
+			}},
+		}
+		cache := newMockCacheStore(t)
+		r := NewResolver(f, cache, "")
+
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+						Ref:    "HEAD",
+					},
+					Hash: HashBytes(archive),
+				},
+			},
+		})
+
+		manifest := buildMinimalManifest("github:owner/repo@HEAD")
+		if _, err := r.Resolve(context.Background(), manifest); err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@HEAD"]; got != 1 {
+			t.Errorf("Fetch called %d times for literal HEAD ref, want 1 (HEAD is mutable)", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`devrune sync` silently missed upstream updates when a package was pinned without a ref (implicit HEAD). After the first resolve cached the tarball, every subsequent sync matched the prior lockfile by CacheKey, pulled the stored dir from the cache, and never re-contacted the remote. Upstream merges to the default branch stayed invisible until the consumer wiped `~/Library/Caches/devrune/packages/<hash>/` by hand.

## Root cause

`cachedDir` (`internal/resolve/resolver.go`) keyed the cache shortcut purely by `SourceRef.CacheKey()`. For a `github:org/repo` entry that key is `github:org/repo@` — deterministically matching the prior entry. With a cached hash for that key, the resolver never called the Fetcher, so a moved upstream HEAD couldn't change the content hash, so the lockfile and cached tree stayed frozen.

## Fix

- Treat the empty ref and the literal `HEAD` as mutable. For those, `cachedDir` returns `ok=false` and forces a fresh `Fetch`. The refetched bytes rehash into the lockfile's new entry, and a cache miss extracts the new tree.
- Pinned refs (tags, commit SHAs, explicit branch names) are unaffected — they still hit the cache shortcut. The user opted into an immutable reference by naming one.

## What's NOT in scope

Explicit branch names like `@main` remain technically mutable but keep the cache shortcut in this PR. Handling them safely needs a cheap HEAD-SHA check against the remote before trusting the cache, which requires widening the `Fetcher` interface and the lockfile schema. I'd rather ship the narrow HEAD-only fix now — it closes the reported bug with a minimal diff — and track the branch-tip case as a follow-up.

## Tests

`TestResolver_EmptyRefBypassesCache` in `internal/resolve/resolver_test.go` with three subtests:

- [x] Empty ref re-fetches even when the prior lockfile already has a matching hash (proves the bug is closed).
- [x] Pinned tag `@v1.0.0` reuses the cache (no network call) so immutable refs keep the performance of the shortcut.
- [x] Literal `@HEAD` behaves like the empty ref.

Full suite: `go test ./...` green.

## Manual verification

In a workspace with `source: github:org/repo` (no ref) pointing at a repo where a new commit just landed:

- [x] Before: `devrune sync` → no diff, local skills stale.
- [x] After: `devrune sync` → new archive fetched, lockfile updated with the fresh content hash, `.claude/skills/*` reflects the upstream changes.