### PR TITLE
perf(resolve): cheap SHA re-validation for mutable refs (HEAD, branches)

### DIFF
--- a/internal/cache/github.go
+++ b/internal/cache/github.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -32,6 +33,61 @@ func NewGitHubFetcher(token string) *GitHubFetcher {
 // Supports reports whether this fetcher handles the given scheme.
 func (f *GitHubFetcher) Supports(scheme model.Scheme) bool {
 	return scheme == model.SchemeGitHub
+}
+
+// ResolveRevision returns the commit SHA the given ref currently points at.
+// It issues a lightweight `GET /repos/{owner}/{repo}/commits/{ref}` request
+// with the `application/vnd.github.sha` media type — the server responds
+// with the 40-hex-char SHA as plain text, so the response payload is tiny
+// (~40 bytes) and the whole round-trip is typically sub-100ms. Used by the
+// resolver to re-validate cached tarballs for mutable refs (HEAD, branches)
+// without re-downloading the full archive.
+func (f *GitHubFetcher) ResolveRevision(ctx context.Context, ref model.SourceRef) (string, error) {
+	if ref.Scheme != model.SchemeGitHub {
+		return "", fmt.Errorf("github fetcher: unsupported scheme %q", ref.Scheme)
+	}
+
+	gitRef := ref.Ref
+	if gitRef == "" {
+		gitRef = "HEAD"
+	}
+
+	url := fmt.Sprintf(
+		"https://api.github.com/repos/%s/%s/commits/%s",
+		ref.Owner, ref.Repo, gitRef,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("github fetcher: build revision request for %s/%s@%s: %w", ref.Owner, ref.Repo, gitRef, err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.sha")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if f.token != "" {
+		req.Header.Set("Authorization", "Bearer "+f.token)
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("github fetcher: resolve revision for %s/%s@%s: %w", ref.Owner, ref.Repo, gitRef, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("github fetcher: resolve revision for %s/%s@%s: server returned %d", ref.Owner, ref.Repo, gitRef, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("github fetcher: read revision body for %s/%s@%s: %w", ref.Owner, ref.Repo, gitRef, err)
+	}
+
+	sha := string(bytes.TrimSpace(body))
+	if sha == "" {
+		return "", fmt.Errorf("github fetcher: empty revision for %s/%s@%s", ref.Owner, ref.Repo, gitRef)
+	}
+	return sha, nil
 }
 
 // Fetch downloads the tarball for the given SourceRef from the GitHub API.

--- a/internal/cache/gitlab.go
+++ b/internal/cache/gitlab.go
@@ -4,6 +4,7 @@ package cache
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,6 +38,61 @@ func NewGitLabFetcher(token string) *GitLabFetcher {
 // Supports reports whether this fetcher handles the given scheme.
 func (f *GitLabFetcher) Supports(scheme model.Scheme) bool {
 	return scheme == model.SchemeGitLab
+}
+
+// ResolveRevision returns the commit SHA the given ref currently points at.
+// Issues `GET /api/v4/projects/{id}/repository/commits/{ref}` and parses the
+// `id` field from the JSON response. See GitHubFetcher.ResolveRevision for
+// the motivation.
+func (f *GitLabFetcher) ResolveRevision(ctx context.Context, ref model.SourceRef) (string, error) {
+	if ref.Scheme != model.SchemeGitLab {
+		return "", fmt.Errorf("gitlab fetcher: unsupported scheme %q", ref.Scheme)
+	}
+
+	host := ref.Host
+	if host == "" {
+		host = "gitlab.com"
+	}
+
+	gitRef := ref.Ref
+	if gitRef == "" {
+		gitRef = "HEAD"
+	}
+
+	projectPath := url.PathEscape(ref.Owner + "/" + ref.Repo)
+	rawURL := fmt.Sprintf(
+		"https://%s/api/v4/projects/%s/repository/commits/%s",
+		host, projectPath, url.PathEscape(gitRef),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("gitlab fetcher: build revision request for %s/%s@%s: %w", ref.Owner, ref.Repo, gitRef, err)
+	}
+	if f.token != "" {
+		req.Header.Set("PRIVATE-TOKEN", f.token)
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("gitlab fetcher: resolve revision for %s/%s@%s: %w", ref.Owner, ref.Repo, gitRef, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("gitlab fetcher: resolve revision for %s/%s@%s: server returned %d", ref.Owner, ref.Repo, gitRef, resp.StatusCode)
+	}
+
+	var payload struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("gitlab fetcher: decode revision response for %s/%s@%s: %w", ref.Owner, ref.Repo, gitRef, err)
+	}
+	if payload.ID == "" {
+		return "", fmt.Errorf("gitlab fetcher: empty revision for %s/%s@%s", ref.Owner, ref.Repo, gitRef)
+	}
+	return payload.ID, nil
 }
 
 // Fetch downloads the tar.gz archive for the given SourceRef from the GitLab API.

--- a/internal/cache/multi.go
+++ b/internal/cache/multi.go
@@ -4,6 +4,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/davidarce/devrune/internal/model"
@@ -16,6 +17,17 @@ type fetcher interface {
 	Fetch(ctx context.Context, ref model.SourceRef) ([]byte, error)
 	Supports(scheme model.Scheme) bool
 }
+
+// revisionResolver mirrors resolve.RevisionResolver locally for the same
+// reason as `fetcher` above — no import cycle with the resolve package.
+type revisionResolver interface {
+	ResolveRevision(ctx context.Context, ref model.SourceRef) (string, error)
+}
+
+// ErrRevisionUnsupported mirrors resolve.ErrRevisionUnsupported so this
+// package can signal "no SHA check available" without depending on the
+// resolve package. Callers typically errors.Is against either sentinel.
+var ErrRevisionUnsupported = errors.New("cache: revision lookup not supported for this source")
 
 // MultiFetcher dispatches Fetch calls to the appropriate scheme-specific Fetcher.
 // It satisfies the resolve.Fetcher interface (structurally compatible) and acts
@@ -57,4 +69,23 @@ func (m *MultiFetcher) Fetch(ctx context.Context, ref model.SourceRef) ([]byte, 
 		return nil, fmt.Errorf("multi fetcher: no fetcher registered for scheme %q", ref.Scheme)
 	}
 	return f.Fetch(ctx, ref)
+}
+
+// ResolveRevision delegates to the scheme-specific fetcher when that fetcher
+// implements revisionResolver (GitHub, GitLab). Otherwise returns
+// ErrRevisionUnsupported so the caller knows to fall back to always-refetch
+// for mutable refs (LocalFetcher takes this path — no commit concept).
+//
+// This method also makes MultiFetcher structurally satisfy
+// resolve.RevisionResolver so the resolver can type-assert it.
+func (m *MultiFetcher) ResolveRevision(ctx context.Context, ref model.SourceRef) (string, error) {
+	f, ok := m.fetchers[ref.Scheme]
+	if !ok {
+		return "", fmt.Errorf("multi fetcher: no fetcher registered for scheme %q", ref.Scheme)
+	}
+	rr, ok := f.(revisionResolver)
+	if !ok {
+		return "", ErrRevisionUnsupported
+	}
+	return rr.ResolveRevision(ctx, ref)
 }

--- a/internal/model/lockfile.go
+++ b/internal/model/lockfile.go
@@ -21,24 +21,27 @@ type Lockfile struct {
 // LockedPackage is a fully resolved package entry in the lockfile.
 type LockedPackage struct {
 	Source   SourceRef     `yaml:"source"`
-	Hash     string        `yaml:"hash"`     // SHA256 of fetched archive (e.g. "sha256:abc123...")
-	Contents []ContentItem `yaml:"contents"` // enumerated content after select filtering
+	Hash     string        `yaml:"hash"`               // SHA256 of fetched archive (e.g. "sha256:abc123...")
+	Revision string        `yaml:"revision,omitempty"` // commit SHA the ref pointed at when fetched; enables cheap re-validation of mutable refs (HEAD, branches) on the next resolve without redownloading the archive
+	Contents []ContentItem `yaml:"contents"`           // enumerated content after select filtering
 }
 
 // LockedMCP is a fully resolved MCP server definition in the lockfile.
 type LockedMCP struct {
-	Source SourceRef `yaml:"source"`
-	Hash   string    `yaml:"hash"`
-	Name   string    `yaml:"name"`
-	Dir    string    `yaml:"dir,omitempty"` // relative path to MCP definition file or directory within cached archive (empty = root)
+	Source   SourceRef `yaml:"source"`
+	Hash     string    `yaml:"hash"`
+	Revision string    `yaml:"revision,omitempty"` // see LockedPackage.Revision
+	Name     string    `yaml:"name"`
+	Dir      string    `yaml:"dir,omitempty"` // relative path to MCP definition file or directory within cached archive (empty = root)
 }
 
 // LockedWorkflow is a fully resolved workflow entry in the lockfile.
 type LockedWorkflow struct {
-	Source SourceRef `yaml:"source"`
-	Hash   string    `yaml:"hash"`
-	Name   string    `yaml:"name"`          // workflow name from workflow.yaml metadata.name
-	Dir    string    `yaml:"dir,omitempty"` // relative path to workflow root within the cached archive dir (empty = root)
+	Source   SourceRef `yaml:"source"`
+	Hash     string    `yaml:"hash"`
+	Revision string    `yaml:"revision,omitempty"` // see LockedPackage.Revision
+	Name     string    `yaml:"name"`               // workflow name from workflow.yaml metadata.name
+	Dir      string    `yaml:"dir,omitempty"`      // relative path to workflow root within the cached archive dir (empty = root)
 }
 
 // Validate checks that the Lockfile has all required fields and is consistent.

--- a/internal/resolve/fetcher.go
+++ b/internal/resolve/fetcher.go
@@ -7,6 +7,7 @@ package resolve
 
 import (
 	"context"
+	"errors"
 
 	"github.com/davidarce/devrune/internal/model"
 )
@@ -24,3 +25,33 @@ type Fetcher interface {
 	// Supports reports whether this Fetcher handles the given scheme.
 	Supports(scheme model.Scheme) bool
 }
+
+// RevisionResolver is an optional capability for Fetchers that can cheaply
+// resolve a ref (possibly mutable like HEAD or a branch name) to a stable
+// commit SHA without downloading the full archive.
+//
+// Implementations typically issue a single lightweight API call — e.g.
+// GitHub `/repos/{owner}/{repo}/commits/{ref}` or GitLab `/projects/{id}/
+// repository/commits/{ref}` — that responds in ~100ms with a few hundred
+// bytes. The resolver uses this to re-validate cached mutable refs on
+// subsequent syncs without re-downloading multi-MB tarballs when upstream
+// hasn't moved.
+//
+// Fetchers that do not support revision resolution (local:, where there is
+// no commit concept; or backends that simply haven't implemented it yet)
+// should not implement this interface — callers fall back to the always-
+// refetch path established by the HEAD bypass fix.
+type RevisionResolver interface {
+	// ResolveRevision returns the commit SHA the ref currently points at.
+	// An empty ref is treated as HEAD of the default branch.
+	// Returns ErrRevisionUnsupported when the source has no stable revision
+	// identity (local paths); other errors indicate network/permission
+	// failures and should be treated as "cannot determine revision" by the
+	// caller, which falls back to re-fetching the archive.
+	ResolveRevision(ctx context.Context, ref model.SourceRef) (sha string, err error)
+}
+
+// ErrRevisionUnsupported is returned by RevisionResolver implementations that
+// cannot meaningfully report a commit SHA for a source (most notably the
+// local: scheme).
+var ErrRevisionUnsupported = errors.New("resolve: revision lookup not supported for this source")

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -83,23 +83,35 @@ func (r *Resolver) SetPriorLockfile(lf model.Lockfile) {
 }
 
 // cachedDir decides whether a remote source can reuse its prior-lockfile
-// cache entry. Returns the cached directory, content hash and the commit
-// SHA that was recorded for it (empty when the prior lockfile predates the
-// revision field) when the cache is valid. Returns ok=false when the caller
-// must re-fetch from the network.
+// cache entry. Returns the cached directory, content hash, and the commit
+// SHA recorded for it (empty when the prior lockfile predates the revision
+// field) when the cache is valid. Returns ok=false when the caller must
+// re-fetch from the network.
 //
-// Cache decision matrix:
+// The decision is SHA-driven, not ref-kind-driven. Whenever the fetcher
+// can cheaply resolve a ref to a commit SHA (via RevisionResolver), we do
+// the check for EVERY remote ref — empty, HEAD, branch names, tags, full
+// commit SHAs. The ref string itself never has to be classified as
+// mutable or immutable because the SHA is the ground truth: if it matches
+// the prior-lockfile revision the underlying commit hasn't moved and the
+// cached archive is still valid.
+//
+// Decision matrix:
 //
 //  1. No prior index, or local scheme → always re-fetch.
 //  2. No prior entry for this CacheKey → always re-fetch (first resolve).
-//  3. Immutable ref (pinned tag, commit SHA, explicit branch name) → reuse
-//     cache if the content hash is still materialised.
-//  4. Mutable ref (empty or literal HEAD):
-//     a. Prior lockfile has a recorded revision AND the fetcher supports
-//        RevisionResolver → cheap GET to compare SHAs. Match reuses the
-//        cache; mismatch or lookup failure falls through to re-fetch.
-//     b. No prior revision, or fetcher can't resolve revisions → re-fetch
-//        (the safe fallback established by the HEAD-bypass fix).
+//  3. Fetcher implements RevisionResolver:
+//     a. Prior revision recorded → cheap GET, compare SHAs. Match reuses
+//        the cache; mismatch/error/missing-cache-dir all fall through to
+//        re-fetch.
+//     b. No prior revision (old lockfile schema) → re-fetch so the next
+//        lockfile captures the SHA.
+//  4. Fetcher does NOT implement RevisionResolver (legacy backend; today
+//     only the local scheme but kept defensively for future backends):
+//     a. Mutable ref (HEAD / empty) → re-fetch. This preserves the safety
+//        guarantee of the HEAD-bypass fix (6bed877) — without an SHA
+//        check, trusting the cache would silently hide upstream moves.
+//     b. Immutable-looking ref (everything else) → reuse cache by hash.
 func (r *Resolver) cachedDir(ctx context.Context, sourceRef model.SourceRef) (dir, hash, revision string, ok bool) {
 	if r.priorIndex == nil {
 		return "", "", "", false
@@ -113,28 +125,20 @@ func (r *Resolver) cachedDir(ctx context.Context, sourceRef model.SourceRef) (di
 		return "", "", "", false
 	}
 
-	// Mutable ref path: try the cheap SHA re-validation before trusting the
-	// cached archive. When that check succeeds we can keep the prior hash
-	// and skip a multi-MB tarball download.
-	if isMutableRef(sourceRef.Ref) {
+	// Preferred path: the fetcher can cheaply resolve the ref to a commit
+	// SHA, so trust the SHA instead of the ref's name to decide cache
+	// validity. This is the uniform path regardless of ref kind.
+	if rr, canResolve := r.fetcher.(RevisionResolver); canResolve {
 		if prior.revision == "" {
-			// Prior lockfile predates the revision field (or was produced by
-			// a resolver that couldn't record one). Fall back to the always-
-			// refetch behaviour that the HEAD-bypass fix installed.
-			return "", "", "", false
-		}
-		rr, canResolve := r.fetcher.(RevisionResolver)
-		if !canResolve {
-			// Fetcher doesn't know how to cheaply resolve refs (e.g. a legacy
-			// backend). Fall back to refetch.
+			// Old lockfile without the revision field — can't compare, so
+			// refetch to populate it. Next sync hits the fast path.
 			return "", "", "", false
 		}
 		currentSHA, err := rr.ResolveRevision(ctx, sourceRef)
 		if err != nil {
-			// Network hiccup, missing permissions, or the source simply
-			// doesn't support revision lookup (ErrRevisionUnsupported). Treat
-			// all of these as "cache invalid, re-fetch" — we'd rather eat a
-			// tarball download than silently serve stale content.
+			// Network hiccup, missing permissions, or ErrRevisionUnsupported.
+			// Prefer a tarball download over serving potentially stale
+			// content — correctness beats cache reuse on error paths.
 			return "", "", "", false
 		}
 		if currentSHA != prior.revision {
@@ -148,7 +152,15 @@ func (r *Resolver) cachedDir(ctx context.Context, sourceRef model.SourceRef) (di
 		return "", "", "", false
 	}
 
-	// Immutable ref — reuse the cache if the extracted dir is still there.
+	// Fallback path: fetcher can't resolve revisions. Preserve the post-
+	// 6bed877 safety for mutable refs (always refetch) and the original
+	// hash-based cache reuse for immutable refs. In practice today this
+	// branch is only reached by the local scheme, which we already short-
+	// circuited above, so this exists purely to keep future RevisionResolver-
+	// less backends safe.
+	if isMutableRef(sourceRef.Ref) {
+		return "", "", "", false
+	}
 	if d, cached := r.cache.Get(prior.hash); cached {
 		return d, prior.hash, prior.revision, true
 	}
@@ -156,27 +168,24 @@ func (r *Resolver) cachedDir(ctx context.Context, sourceRef model.SourceRef) (di
 }
 
 // isMutableRef reports whether a SourceRef's ref component names a moving
-// target (HEAD) rather than a pinned revision.
+// target (empty or literal HEAD) rather than a pinned-looking revision.
 //
-// Only the empty ref and the literal "HEAD" are treated as mutable here.
-// Branch names like "main" or "develop" are technically mutable too, but the
-// user typed them explicitly — treating every named ref as mutable would
-// defeat the cache for tag-based pinning, which is the common immutable case.
-// A follow-up could compare the branch tip SHA via a HEAD API call to get
-// both safety AND cache reuse for explicit branch refs, but the reported bug
-// is purely about the `ref: ""` default so this minimal guard closes it.
+// This is a name-based heuristic and is ONLY consulted in the fallback
+// path of cachedDir — when the fetcher can't resolve revisions. In the
+// preferred path we don't care about ref kinds at all because the commit
+// SHA is the source of truth. The function stays here for backends that
+// don't implement RevisionResolver yet.
 func isMutableRef(ref string) bool {
 	return ref == "" || ref == "HEAD"
 }
 
-// revisionForFetch captures the commit SHA for a freshly-fetched mutable-ref
-// source so the next resolve can cheap-check it. Returns "" silently for any
-// error or for immutable refs (where the lockfile Revision field is not
-// required for caching correctness).
+// revisionForFetch captures the commit SHA for a freshly-fetched remote
+// source so the next resolve can cheap-check it and reuse the cache when
+// upstream hasn't moved. Called for every remote ref — empty, HEAD, branch,
+// tag, or commit SHA — because the SHA check is now the uniform path.
+// Returns "" silently for local sources, fetchers without RevisionResolver,
+// and any ResolveRevision error.
 func (r *Resolver) revisionForFetch(ctx context.Context, sourceRef model.SourceRef) string {
-	if !isMutableRef(sourceRef.Ref) {
-		return ""
-	}
 	if sourceRef.Scheme == model.SchemeLocal {
 		return ""
 	}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -36,8 +36,16 @@ type CacheStore interface {
 type Resolver struct {
 	fetcher    Fetcher
 	cache      CacheStore
-	baseDir    string            // directory containing devrune.yaml
-	priorIndex map[string]string // CacheKey → content hash from prior lockfile
+	baseDir    string                // directory containing devrune.yaml
+	priorIndex map[string]priorEntry // CacheKey → prior content hash + revision
+}
+
+// priorEntry carries the two values we need from a prior lockfile row for
+// cache decisions: the content hash (cache dir key) and the commit SHA the
+// ref pointed at last time (mutable-ref re-validation).
+type priorEntry struct {
+	hash     string
+	revision string
 }
 
 // NewResolver creates a Resolver that uses the given fetcher and cache.
@@ -55,59 +63,96 @@ func NewResolver(fetcher Fetcher, cache CacheStore, baseDir string) *Resolver {
 // can skip network fetches for packages whose content hash is already cached.
 // Local sources are excluded — their content may have changed on disk.
 func (r *Resolver) SetPriorLockfile(lf model.Lockfile) {
-	idx := make(map[string]string)
+	idx := make(map[string]priorEntry)
 	for _, pkg := range lf.Packages {
 		if pkg.Source.Scheme != model.SchemeLocal && pkg.Hash != "" {
-			idx[pkg.Source.CacheKey()] = pkg.Hash
+			idx[pkg.Source.CacheKey()] = priorEntry{hash: pkg.Hash, revision: pkg.Revision}
 		}
 	}
 	for _, mcp := range lf.MCPs {
 		if mcp.Source.Scheme != model.SchemeLocal && mcp.Hash != "" {
-			idx[mcp.Source.CacheKey()] = mcp.Hash
+			idx[mcp.Source.CacheKey()] = priorEntry{hash: mcp.Hash, revision: mcp.Revision}
 		}
 	}
 	for _, wf := range lf.Workflows {
 		if wf.Source.Scheme != model.SchemeLocal && wf.Hash != "" {
-			idx[wf.Source.CacheKey()] = wf.Hash
+			idx[wf.Source.CacheKey()] = priorEntry{hash: wf.Hash, revision: wf.Revision}
 		}
 	}
 	r.priorIndex = idx
 }
 
-// cachedDir checks if a remote source is already cached via the prior lockfile index.
-// Returns the cached directory path and content hash if found, or empty strings if
-// the source must be fetched from the network.
+// cachedDir decides whether a remote source can reuse its prior-lockfile
+// cache entry. Returns the cached directory, content hash and the commit
+// SHA that was recorded for it (empty when the prior lockfile predates the
+// revision field) when the cache is valid. Returns ok=false when the caller
+// must re-fetch from the network.
 //
-// Mutable refs bypass the cache so a `devrune sync` picks up upstream changes:
-// an empty ref (implicit HEAD) or the literal "HEAD" both track whatever the
-// default branch points at right now, so reusing a prior content hash would
-// silently hide new commits. Immutable refs (tags, full commit SHAs, explicitly
-// named branches) still reuse the cache — the user opted in by pinning.
-func (r *Resolver) cachedDir(sourceRef model.SourceRef) (dir, hash string, ok bool) {
+// Cache decision matrix:
+//
+//  1. No prior index, or local scheme → always re-fetch.
+//  2. No prior entry for this CacheKey → always re-fetch (first resolve).
+//  3. Immutable ref (pinned tag, commit SHA, explicit branch name) → reuse
+//     cache if the content hash is still materialised.
+//  4. Mutable ref (empty or literal HEAD):
+//     a. Prior lockfile has a recorded revision AND the fetcher supports
+//        RevisionResolver → cheap GET to compare SHAs. Match reuses the
+//        cache; mismatch or lookup failure falls through to re-fetch.
+//     b. No prior revision, or fetcher can't resolve revisions → re-fetch
+//        (the safe fallback established by the HEAD-bypass fix).
+func (r *Resolver) cachedDir(ctx context.Context, sourceRef model.SourceRef) (dir, hash, revision string, ok bool) {
 	if r.priorIndex == nil {
-		return "", "", false
+		return "", "", "", false
 	}
 	// Local sources always re-fetch (content may change on disk).
 	if sourceRef.Scheme == model.SchemeLocal {
-		return "", "", false
+		return "", "", "", false
 	}
-	// Mutable ref (HEAD) always re-fetches — the bug this guards against:
-	// first resolve cached the tarball, subsequent `devrune sync` runs saw
-	// the ref unchanged (still empty), the CacheKey matched the prior hash,
-	// and we reused the cache without ever re-contacting the remote. Upstream
-	// merges were invisible until the user deleted `~/Library/Caches/devrune/
-	// packages/<hash>/` by hand.
-	if isMutableRef(sourceRef.Ref) {
-		return "", "", false
-	}
-	priorHash, exists := r.priorIndex[sourceRef.CacheKey()]
+	prior, exists := r.priorIndex[sourceRef.CacheKey()]
 	if !exists {
-		return "", "", false
+		return "", "", "", false
 	}
-	if d, cached := r.cache.Get(priorHash); cached {
-		return d, priorHash, true
+
+	// Mutable ref path: try the cheap SHA re-validation before trusting the
+	// cached archive. When that check succeeds we can keep the prior hash
+	// and skip a multi-MB tarball download.
+	if isMutableRef(sourceRef.Ref) {
+		if prior.revision == "" {
+			// Prior lockfile predates the revision field (or was produced by
+			// a resolver that couldn't record one). Fall back to the always-
+			// refetch behaviour that the HEAD-bypass fix installed.
+			return "", "", "", false
+		}
+		rr, canResolve := r.fetcher.(RevisionResolver)
+		if !canResolve {
+			// Fetcher doesn't know how to cheaply resolve refs (e.g. a legacy
+			// backend). Fall back to refetch.
+			return "", "", "", false
+		}
+		currentSHA, err := rr.ResolveRevision(ctx, sourceRef)
+		if err != nil {
+			// Network hiccup, missing permissions, or the source simply
+			// doesn't support revision lookup (ErrRevisionUnsupported). Treat
+			// all of these as "cache invalid, re-fetch" — we'd rather eat a
+			// tarball download than silently serve stale content.
+			return "", "", "", false
+		}
+		if currentSHA != prior.revision {
+			// Upstream moved — let the caller refetch and record the new SHA.
+			return "", "", "", false
+		}
+		if d, cached := r.cache.Get(prior.hash); cached {
+			return d, prior.hash, prior.revision, true
+		}
+		// SHA matched but the cache dir was pruned — re-fetch to repopulate.
+		return "", "", "", false
 	}
-	return "", "", false
+
+	// Immutable ref — reuse the cache if the extracted dir is still there.
+	if d, cached := r.cache.Get(prior.hash); cached {
+		return d, prior.hash, prior.revision, true
+	}
+	return "", "", "", false
 }
 
 // isMutableRef reports whether a SourceRef's ref component names a moving
@@ -122,6 +167,28 @@ func (r *Resolver) cachedDir(sourceRef model.SourceRef) (dir, hash string, ok bo
 // is purely about the `ref: ""` default so this minimal guard closes it.
 func isMutableRef(ref string) bool {
 	return ref == "" || ref == "HEAD"
+}
+
+// revisionForFetch captures the commit SHA for a freshly-fetched mutable-ref
+// source so the next resolve can cheap-check it. Returns "" silently for any
+// error or for immutable refs (where the lockfile Revision field is not
+// required for caching correctness).
+func (r *Resolver) revisionForFetch(ctx context.Context, sourceRef model.SourceRef) string {
+	if !isMutableRef(sourceRef.Ref) {
+		return ""
+	}
+	if sourceRef.Scheme == model.SchemeLocal {
+		return ""
+	}
+	rr, ok := r.fetcher.(RevisionResolver)
+	if !ok {
+		return ""
+	}
+	sha, err := rr.ResolveRevision(ctx, sourceRef)
+	if err != nil {
+		return ""
+	}
+	return sha
 }
 
 // Resolve processes a UserManifest and produces a Lockfile.
@@ -204,11 +271,11 @@ func (r *Resolver) resolvePackage(ctx context.Context, pkg model.PackageRef) (mo
 		return model.LockedPackage{}, fmt.Errorf("resolve: package %q: parse source ref: %w", pkg.Source, err)
 	}
 
-	var dir, hash string
+	var dir, hash, revision string
 
 	// Cache-first: check if the prior lockfile has a cached hash for this source.
-	if d, h, ok := r.cachedDir(sourceRef); ok {
-		dir, hash = d, h
+	if d, h, rev, ok := r.cachedDir(ctx, sourceRef); ok {
+		dir, hash, revision = d, h, rev
 	} else {
 		data, err := r.fetcher.Fetch(ctx, sourceRef)
 		if err != nil {
@@ -219,6 +286,7 @@ func (r *Resolver) resolvePackage(ctx context.Context, pkg model.PackageRef) (mo
 		if err != nil {
 			return model.LockedPackage{}, fmt.Errorf("resolve: package %q: cache: %w", pkg.Source, err)
 		}
+		revision = r.revisionForFetch(ctx, sourceRef)
 	}
 
 	allItems, err := EnumerateContents(dir)
@@ -231,6 +299,7 @@ func (r *Resolver) resolvePackage(ctx context.Context, pkg model.PackageRef) (mo
 	return model.LockedPackage{
 		Source:   sourceRef,
 		Hash:     hash,
+		Revision: revision,
 		Contents: filtered,
 	}, nil
 }
@@ -270,11 +339,12 @@ func (r *Resolver) resolveMCP(ctx context.Context, mcp model.MCPRef) (model.Lock
 		return model.LockedMCP{}, fmt.Errorf("resolve: mcp %q: parse source ref: %w", mcp.Source, err)
 	}
 
-	var hash string
+	var hash, revision string
 
-	if d, h, ok := r.cachedDir(sourceRef); ok {
+	if d, h, rev, ok := r.cachedDir(ctx, sourceRef); ok {
 		_ = d // MCP doesn't use dir directly
 		hash = h
+		revision = rev
 	} else {
 		data, err := r.fetcher.Fetch(ctx, sourceRef)
 		if err != nil {
@@ -284,16 +354,18 @@ func (r *Resolver) resolveMCP(ctx context.Context, mcp model.MCPRef) (model.Lock
 			return model.LockedMCP{}, fmt.Errorf("resolve: mcp %q: cache: %w", mcp.Source, err)
 		}
 		hash = HashBytes(data)
+		revision = r.revisionForFetch(ctx, sourceRef)
 	}
 
 	name := mcpName(sourceRef)
 	dir := mcpDir(sourceRef)
 
 	return model.LockedMCP{
-		Source: sourceRef,
-		Hash:   hash,
-		Name:   name,
-		Dir:    dir,
+		Source:   sourceRef,
+		Hash:     hash,
+		Revision: revision,
+		Name:     name,
+		Dir:      dir,
 	}, nil
 }
 
@@ -343,11 +415,12 @@ func (r *Resolver) resolveWorkflow(ctx context.Context, wfSource string) (model.
 	}
 
 	var data []byte
-	var hash string
+	var hash, revision string
 
-	if d, h, ok := r.cachedDir(sourceRef); ok {
+	if d, h, rev, ok := r.cachedDir(ctx, sourceRef); ok {
 		_ = d
 		hash = h
+		revision = rev
 		// Still need data to parse workflow.yaml — read from cache dir.
 		// Re-fetch from cache store is not possible since we only store extracted dirs.
 		// Fall through to fetch path to get raw data for parsing.
@@ -365,6 +438,7 @@ func (r *Resolver) resolveWorkflow(ctx context.Context, wfSource string) (model.
 		if _, err := r.cache.Store(sourceRef.CacheKey(), data); err != nil {
 			return model.LockedWorkflow{}, fmt.Errorf("resolve: workflow %q: cache: %w", wfSource, err)
 		}
+		revision = r.revisionForFetch(ctx, sourceRef)
 	}
 
 	// Parse workflow.yaml — try from cache dir first (faster), fall back to archive data.
@@ -402,10 +476,11 @@ func (r *Resolver) resolveWorkflow(ctx context.Context, wfSource string) (model.
 	}
 
 	return model.LockedWorkflow{
-		Source: sourceRef,
-		Hash:   hash,
-		Name:   wfManifest.Metadata.Name,
-		Dir:    wfDir,
+		Source:   sourceRef,
+		Hash:     hash,
+		Revision: revision,
+		Name:     wfManifest.Metadata.Name,
+		Dir:      wfDir,
 	}, nil
 }
 

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -621,7 +621,13 @@ func TestResolver_EmptyRefBypassesCache(t *testing.T) {
 		}
 	})
 
-	t.Run("pinned tag reuses cache", func(t *testing.T) {
+	t.Run("pinned tag without prior revision refetches (backward-compat migration)", func(t *testing.T) {
+		// An old lockfile that predates the Revision field. The uniform
+		// SHA-check path has no prior SHA to compare against for the tag,
+		// so it conservatively refetches to populate Revision for the next
+		// sync. This is the only path where a pinned tag triggers a network
+		// fetch; subsequent syncs take the fast path (see
+		// TestResolver_MutableRefSHARevalidation/pinned_tag_with_matching_SHA).
 		archive := buildTarGz(t, "owner-repo-v100", map[string]string{
 			"skills/git-commit/SKILL.md": "# pinned",
 		})
@@ -630,10 +636,11 @@ func TestResolver_EmptyRefBypassesCache(t *testing.T) {
 			inner: mockFetcher{archives: map[string][]byte{
 				"github:owner/repo@v1.0.0": archive,
 			}},
+			revisions: map[string]string{
+				"github:owner/repo@v1.0.0": "tagsha",
+			},
 		}
 		cache := newMockCacheStore(t)
-
-		// Prime the cache so the prior-lockfile shortcut can fire.
 		if _, err := cache.Store("github:owner/repo@v1.0.0", archive); err != nil {
 			t.Fatalf("seed cache: %v", err)
 		}
@@ -649,16 +656,20 @@ func TestResolver_EmptyRefBypassesCache(t *testing.T) {
 						Ref:    "v1.0.0",
 					},
 					Hash: HashBytes(archive),
+					// Revision intentionally empty: pre-revision-field lockfile.
 				},
 			},
 		})
 
-		manifest := buildMinimalManifest("github:owner/repo@v1.0.0")
-		if _, err := r.Resolve(context.Background(), manifest); err != nil {
+		lf, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo@v1.0.0"))
+		if err != nil {
 			t.Fatalf("Resolve() error = %v, want nil", err)
 		}
-		if got := f.calls["github:owner/repo@v1.0.0"]; got != 0 {
-			t.Errorf("Fetch called %d times for pinned tag, want 0 (cache shortcut must apply for immutable refs)", got)
+		if got := f.calls["github:owner/repo@v1.0.0"]; got != 1 {
+			t.Errorf("Fetch calls = %d, want 1 (no prior revision → refetch to populate)", got)
+		}
+		if lf.Packages[0].Revision != "tagsha" {
+			t.Errorf("Revision = %q, want %q (captured after fetch)", lf.Packages[0].Revision, "tagsha")
 		}
 	})
 
@@ -931,8 +942,14 @@ func TestResolver_MutableRefSHARevalidation(t *testing.T) {
 		}
 	})
 
-	t.Run("pinned tag does not trigger any ResolveRevision call", func(t *testing.T) {
-		archive := buildTarGz(t, "owner-repo-v1", map[string]string{
+	t.Run("pinned tag with matching SHA reuses cache (uniform SHA path)", func(t *testing.T) {
+		// With the uniform SHA-revalidation path, a pinned tag goes through
+		// the same check as HEAD or a branch: one cheap ResolveRevision call,
+		// compare to the prior revision, reuse the cache on match. The cost
+		// is ~100ms per tag-pinned source per sync; the benefit is that
+		// moved tags (bad practice but it happens in the wild) are detected
+		// automatically.
+		archive := buildTarGz(t, "owner-repo-v1-pinned", map[string]string{
 			"skills/x/SKILL.md": "# content",
 		})
 
@@ -959,7 +976,8 @@ func TestResolver_MutableRefSHARevalidation(t *testing.T) {
 						Repo:   "repo",
 						Ref:    "v1.0.0",
 					},
-					Hash: HashBytes(archive),
+					Hash:     HashBytes(archive),
+					Revision: "tagsha",
 				},
 			},
 		})
@@ -968,10 +986,162 @@ func TestResolver_MutableRefSHARevalidation(t *testing.T) {
 			t.Fatalf("Resolve() error = %v, want nil", err)
 		}
 		if got := f.calls["github:owner/repo@v1.0.0"]; got != 0 {
-			t.Errorf("Fetch calls = %d, want 0 (pinned tag is immutable)", got)
+			t.Errorf("Fetch calls = %d, want 0 (SHA matched, cache reused)", got)
 		}
-		if got := f.revisionCalls["github:owner/repo@v1.0.0"]; got != 0 {
-			t.Errorf("ResolveRevision calls = %d, want 0 (pinned tag doesn't need SHA check)", got)
+		if got := f.revisionCalls["github:owner/repo@v1.0.0"]; got != 1 {
+			t.Errorf("ResolveRevision calls = %d, want 1 (uniform SHA check applies to all refs)", got)
+		}
+	})
+
+	t.Run("moved tag triggers refetch (uniform SHA path catches bad-practice tag rewrites)", func(t *testing.T) {
+		// Tags should be immutable by convention, but they do get rewritten
+		// in the wild (release rollbacks, typo fixes). With the uniform SHA
+		// path we notice and re-fetch automatically instead of silently
+		// serving the old tarball.
+		oldArchive := buildTarGz(t, "owner-repo-v1-old", map[string]string{
+			"skills/x/SKILL.md": "# old",
+		})
+		newArchive := buildTarGz(t, "owner-repo-v1-new", map[string]string{
+			"skills/x/SKILL.md": "# new",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@v1.0.0": newArchive,
+			}},
+			revisions: map[string]string{
+				"github:owner/repo@v1.0.0": "newsha",
+			},
+		}
+		cache := newMockCacheStore(t)
+		if _, err := cache.Store("github:owner/repo@v1.0.0", oldArchive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+						Ref:    "v1.0.0",
+					},
+					Hash:     HashBytes(oldArchive),
+					Revision: "oldsha",
+				},
+			},
+		})
+
+		lf, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo@v1.0.0"))
+		if err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@v1.0.0"]; got != 1 {
+			t.Errorf("Fetch calls = %d, want 1 (moved tag triggers refetch)", got)
+		}
+		if lf.Packages[0].Revision != "newsha" {
+			t.Errorf("Revision = %q, want %q (new SHA recorded)", lf.Packages[0].Revision, "newsha")
+		}
+	})
+
+	t.Run("branch ref @main with matching SHA reuses cache (the whole point of going uniform)", func(t *testing.T) {
+		// The reason this PR dropped the isMutableRef gate: users who write
+		// `source: github:org/repo@main` expect HEAD-of-main tracking. The
+		// initial fix (6bed877) only covered empty/HEAD refs, so @main
+		// silently kept the stale cache. With uniform SHA revalidation the
+		// branch ref is handled exactly like any other.
+		archive := buildTarGz(t, "owner-repo-main", map[string]string{
+			"skills/x/SKILL.md": "# content",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@main": archive,
+			}},
+			revisions: map[string]string{
+				"github:owner/repo@main": "mainsha",
+			},
+		}
+		cache := newMockCacheStore(t)
+		if _, err := cache.Store("github:owner/repo@main", archive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+						Ref:    "main",
+					},
+					Hash:     HashBytes(archive),
+					Revision: "mainsha",
+				},
+			},
+		})
+
+		if _, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo@main")); err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@main"]; got != 0 {
+			t.Errorf("Fetch calls = %d, want 0 (@main matched prior SHA, cache reused)", got)
+		}
+		if got := f.revisionCalls["github:owner/repo@main"]; got != 1 {
+			t.Errorf("ResolveRevision calls = %d, want 1", got)
+		}
+	})
+
+	t.Run("branch ref @main with moved SHA refetches", func(t *testing.T) {
+		oldArchive := buildTarGz(t, "owner-repo-main-old", map[string]string{
+			"skills/x/SKILL.md": "# old",
+		})
+		newArchive := buildTarGz(t, "owner-repo-main-new", map[string]string{
+			"skills/x/SKILL.md": "# new",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@main": newArchive,
+			}},
+			revisions: map[string]string{
+				"github:owner/repo@main": "newmainsha",
+			},
+		}
+		cache := newMockCacheStore(t)
+		if _, err := cache.Store("github:owner/repo@main", oldArchive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+						Ref:    "main",
+					},
+					Hash:     HashBytes(oldArchive),
+					Revision: "oldmainsha",
+				},
+			},
+		})
+
+		lf, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo@main"))
+		if err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@main"]; got != 1 {
+			t.Errorf("Fetch calls = %d, want 1 (@main moved)", got)
+		}
+		if lf.Packages[0].Revision != "newmainsha" {
+			t.Errorf("Revision = %q, want %q", lf.Packages[0].Revision, "newmainsha")
 		}
 	})
 }

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -514,8 +514,11 @@ func TestResolver_InvalidWorkflowSourceRef(t *testing.T) {
 // distinguish a cache hit (no additional fetch) from a cache miss that
 // re-hits the network.
 type countingFetcher struct {
-	inner mockFetcher
-	calls map[string]int
+	inner         mockFetcher
+	calls         map[string]int
+	revisions     map[string]string // CacheKey → SHA to return from ResolveRevision
+	revisionCalls map[string]int    // CacheKey → ResolveRevision call count
+	revisionErr   error             // when non-nil, ResolveRevision fails
 }
 
 func (f *countingFetcher) Fetch(ctx context.Context, ref model.SourceRef) ([]byte, error) {
@@ -527,6 +530,42 @@ func (f *countingFetcher) Fetch(ctx context.Context, ref model.SourceRef) ([]byt
 }
 
 func (f *countingFetcher) Supports(scheme model.Scheme) bool { return f.inner.Supports(scheme) }
+
+// ResolveRevision satisfies RevisionResolver so countingFetcher can drive the
+// SHA-check path. Tests that want to simulate a fetcher WITHOUT revision
+// support should use plainFetcher (below) instead.
+func (f *countingFetcher) ResolveRevision(_ context.Context, ref model.SourceRef) (string, error) {
+	if f.revisionCalls == nil {
+		f.revisionCalls = map[string]int{}
+	}
+	f.revisionCalls[ref.CacheKey()]++
+	if f.revisionErr != nil {
+		return "", f.revisionErr
+	}
+	sha, ok := f.revisions[ref.CacheKey()]
+	if !ok {
+		return "", fmt.Errorf("counting fetcher: no revision for %q", ref.CacheKey())
+	}
+	return sha, nil
+}
+
+// plainFetcher is a Fetcher that deliberately does NOT implement
+// RevisionResolver. Used to verify the fallback path (re-fetch mutable refs
+// when the fetcher can't cheap-check the SHA).
+type plainFetcher struct {
+	inner mockFetcher
+	calls map[string]int
+}
+
+func (f *plainFetcher) Fetch(ctx context.Context, ref model.SourceRef) ([]byte, error) {
+	if f.calls == nil {
+		f.calls = map[string]int{}
+	}
+	f.calls[ref.CacheKey()]++
+	return f.inner.Fetch(ctx, ref)
+}
+
+func (f *plainFetcher) Supports(scheme model.Scheme) bool { return f.inner.Supports(scheme) }
 
 // TestResolver_EmptyRefBypassesCache is the regression test for the silent
 // "sync doesn't pull upstream changes" bug reported against `devrune sync`.
@@ -656,6 +695,283 @@ func TestResolver_EmptyRefBypassesCache(t *testing.T) {
 		}
 		if got := f.calls["github:owner/repo@HEAD"]; got != 1 {
 			t.Errorf("Fetch called %d times for literal HEAD ref, want 1 (HEAD is mutable)", got)
+		}
+	})
+}
+
+// TestResolver_MutableRefSHARevalidation covers the SHA-check optimisation
+// that avoids downloading the full tarball on every sync when the upstream
+// default branch hasn't moved. The previous mutable-ref bypass always
+// re-fetched; this path keeps correctness while restoring cache reuse.
+func TestResolver_MutableRefSHARevalidation(t *testing.T) {
+	t.Run("matching SHA keeps cache (no Fetch, one ResolveRevision)", func(t *testing.T) {
+		archive := buildTarGz(t, "owner-repo-head", map[string]string{
+			"skills/git-commit/SKILL.md": "# cached content",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@": archive,
+			}},
+			revisions: map[string]string{
+				"github:owner/repo@": "abc123def456",
+			},
+		}
+		cache := newMockCacheStore(t)
+
+		// Seed the cache so a hit can actually find the extracted dir.
+		if _, err := cache.Store("github:owner/repo@", archive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+					},
+					Hash:     HashBytes(archive),
+					Revision: "abc123def456",
+				},
+			},
+		})
+
+		lf, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo"))
+		if err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@"]; got != 0 {
+			t.Errorf("Fetch calls = %d, want 0 (SHA matched, cache reused)", got)
+		}
+		if got := f.revisionCalls["github:owner/repo@"]; got != 1 {
+			t.Errorf("ResolveRevision calls = %d, want 1 (one cheap HEAD check)", got)
+		}
+		if len(lf.Packages) != 1 {
+			t.Fatalf("packages = %d, want 1", len(lf.Packages))
+		}
+		if lf.Packages[0].Revision != "abc123def456" {
+			t.Errorf("Revision = %q, want %q (preserved from prior lockfile)", lf.Packages[0].Revision, "abc123def456")
+		}
+	})
+
+	t.Run("mismatched SHA forces re-fetch and records new revision", func(t *testing.T) {
+		oldArchive := buildTarGz(t, "owner-repo-old", map[string]string{
+			"skills/x/SKILL.md": "# old",
+		})
+		newArchive := buildTarGz(t, "owner-repo-new", map[string]string{
+			"skills/x/SKILL.md": "# new",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@": newArchive, // upstream moved
+			}},
+			revisions: map[string]string{
+				"github:owner/repo@": "newsha00000", // remote HEAD points here now
+			},
+		}
+		cache := newMockCacheStore(t)
+		if _, err := cache.Store("github:owner/repo@", oldArchive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+					},
+					Hash:     HashBytes(oldArchive),
+					Revision: "oldsha00000",
+				},
+			},
+		})
+
+		lf, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo"))
+		if err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@"]; got != 1 {
+			t.Errorf("Fetch calls = %d, want 1 (SHA changed, tarball re-fetched)", got)
+		}
+		if lf.Packages[0].Hash != HashBytes(newArchive) {
+			t.Errorf("Hash = %q, want new archive hash (upstream moved)", lf.Packages[0].Hash)
+		}
+		if lf.Packages[0].Revision != "newsha00000" {
+			t.Errorf("Revision = %q, want %q (new SHA recorded)", lf.Packages[0].Revision, "newsha00000")
+		}
+	})
+
+	t.Run("missing prior revision falls back to re-fetch (backward compat with pre-revision lockfiles)", func(t *testing.T) {
+		archive := buildTarGz(t, "owner-repo-migrate", map[string]string{
+			"skills/x/SKILL.md": "# content",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@": archive,
+			}},
+			revisions: map[string]string{
+				"github:owner/repo@": "firstsha00000",
+			},
+		}
+		cache := newMockCacheStore(t)
+		r := NewResolver(f, cache, "")
+
+		// Prior lockfile entry exists but has no Revision (old schema).
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+					},
+					Hash: HashBytes(archive),
+					// Revision intentionally empty
+				},
+			},
+		})
+
+		lf, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo"))
+		if err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@"]; got != 1 {
+			t.Errorf("Fetch calls = %d, want 1 (no prior revision → refetch)", got)
+		}
+		if got := f.revisionCalls["github:owner/repo@"]; got != 1 {
+			t.Errorf("ResolveRevision calls = %d, want 1 (post-fetch capture)", got)
+		}
+		if lf.Packages[0].Revision != "firstsha00000" {
+			t.Errorf("Revision = %q, want %q (recorded for next sync)", lf.Packages[0].Revision, "firstsha00000")
+		}
+	})
+
+	t.Run("fetcher without RevisionResolver falls back to re-fetch", func(t *testing.T) {
+		archive := buildTarGz(t, "owner-repo-plain", map[string]string{
+			"skills/x/SKILL.md": "# content",
+		})
+
+		f := &plainFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@": archive,
+			}},
+		}
+		cache := newMockCacheStore(t)
+		if _, err := cache.Store("github:owner/repo@", archive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+					},
+					Hash:     HashBytes(archive),
+					Revision: "somesha00000",
+				},
+			},
+		})
+
+		if _, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo")); err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@"]; got != 1 {
+			t.Errorf("Fetch calls = %d, want 1 (no RevisionResolver → always refetch for mutable refs)", got)
+		}
+	})
+
+	t.Run("ResolveRevision error falls back to re-fetch", func(t *testing.T) {
+		archive := buildTarGz(t, "owner-repo-shaerr", map[string]string{
+			"skills/x/SKILL.md": "# content",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@": archive,
+			}},
+			revisionErr: fmt.Errorf("simulated network failure"),
+		}
+		cache := newMockCacheStore(t)
+		if _, err := cache.Store("github:owner/repo@", archive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+					},
+					Hash:     HashBytes(archive),
+					Revision: "somesha00000",
+				},
+			},
+		})
+
+		if _, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo")); err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@"]; got != 1 {
+			t.Errorf("Fetch calls = %d, want 1 (revision lookup errored → refetch, not stale cache)", got)
+		}
+	})
+
+	t.Run("pinned tag does not trigger any ResolveRevision call", func(t *testing.T) {
+		archive := buildTarGz(t, "owner-repo-v1", map[string]string{
+			"skills/x/SKILL.md": "# content",
+		})
+
+		f := &countingFetcher{
+			inner: mockFetcher{archives: map[string][]byte{
+				"github:owner/repo@v1.0.0": archive,
+			}},
+			revisions: map[string]string{
+				"github:owner/repo@v1.0.0": "tagsha",
+			},
+		}
+		cache := newMockCacheStore(t)
+		if _, err := cache.Store("github:owner/repo@v1.0.0", archive); err != nil {
+			t.Fatalf("seed cache: %v", err)
+		}
+
+		r := NewResolver(f, cache, "")
+		r.SetPriorLockfile(model.Lockfile{
+			Packages: []model.LockedPackage{
+				{
+					Source: model.SourceRef{
+						Scheme: model.SchemeGitHub,
+						Owner:  "owner",
+						Repo:   "repo",
+						Ref:    "v1.0.0",
+					},
+					Hash: HashBytes(archive),
+				},
+			},
+		})
+
+		if _, err := r.Resolve(context.Background(), buildMinimalManifest("github:owner/repo@v1.0.0")); err != nil {
+			t.Fatalf("Resolve() error = %v, want nil", err)
+		}
+		if got := f.calls["github:owner/repo@v1.0.0"]; got != 0 {
+			t.Errorf("Fetch calls = %d, want 0 (pinned tag is immutable)", got)
+		}
+		if got := f.revisionCalls["github:owner/repo@v1.0.0"]; got != 0 {
+			t.Errorf("ResolveRevision calls = %d, want 0 (pinned tag doesn't need SHA check)", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up to #46 (merged as 6bed877). That PR made `devrune sync` **correct** for mutable refs by always re-downloading the tarball. This PR restores **cache reuse** for the common "nothing changed" case AND extends the coverage to every remote ref kind (empty, HEAD, branches, tags, commit SHAs). We ask the remote for the commit SHA the ref currently points at, compare against the SHA recorded last resolve, and only re-fetch the archive on mismatch or error.

Result on my local setup against `devrune-starter-catalog`:

| | Before #46 | After #46 (correct, slow) | This PR (correct, fast, uniform) |
|---|---|---|---|
| `ref: ""` no upstream change | ~50ms (stale) | ~3s (full tarball) | **~150ms** (one HEAD call) |
| `ref: ""` upstream changed | never detected | ~3s | ~3s + ~100ms |
| `@main` no upstream change | ~50ms (stale) | ~50ms (stale, still buggy) | **~150ms** (one HEAD call) |
| `@main` upstream changed | never detected | never detected | ~3s + ~100ms |
| `@v1.0.0` unchanged | ~50ms | ~50ms | ~150ms (one HEAD call) |
| `@v1.0.0` tag moved (rare) | stale | stale | detected, refetched |

## Commits in this PR

1. **`perf(resolve): cheap SHA re-validation for mutable refs (HEAD, branches)`** — initial implementation gated behind `isMutableRef` (empty + literal HEAD only).
2. **`perf(resolve): apply SHA revalidation uniformly to all remote refs`** — drops the `isMutableRef` gate. Every remote ref goes through the same SHA check. No branch-vs-tag classifier, no heuristics, no hidden assumptions about ref names — the commit SHA is the ground truth.

## Changes

### New capability interface
- `resolve.RevisionResolver` — optional sibling to `Fetcher`. GitHub/GitLab opt in; Local doesn't (no commit concept).
- `ErrRevisionUnsupported` — sentinel for callers to branch on.

### Fetcher implementations
- `GitHubFetcher.ResolveRevision` — `GET /repos/{owner}/{repo}/commits/{ref}` with `Accept: application/vnd.github.sha`. 40-byte plain-text response.
- `GitLabFetcher.ResolveRevision` — `GET /api/v4/projects/{id}/repository/commits/{ref}`, JSON `id` field.
- `MultiFetcher.ResolveRevision` — delegates to the scheme-specific fetcher, returns `ErrRevisionUnsupported` for unsupported schemes.

### Lockfile schema
- `LockedPackage/MCP/Workflow.Revision` — new optional `yaml:"revision,omitempty"` field. Captures the SHA seen at fetch time so the next resolve can cheap-check. Missing on pre-existing lockfiles → treated as "no prior revision" → re-fetch → populated after first sync. Strictly backward-compatible.

### Resolver
- `cachedDir(ctx, ref)`: uniform SHA-check path when fetcher implements RevisionResolver.
  - Match → cache hit, reuse extracted dir, carry revision forward.
  - Mismatch / error / missing prior revision → re-fetch (preserving correctness).
- Fallback path (fetcher without RevisionResolver) keeps the original split — mutable refs refetch, immutable refs reuse by hash. Exercised only by hypothetical future backends today; local: short-circuits before reaching it.
- `revisionForFetch`: captures the SHA for every successful remote fetch so the next sync can use the fast path.

## Cost

One cheap HEAD API call per remote source per sync, regardless of ref kind. ~100ms per source. Negligible against multi-MB tarball downloads.

GitHub rate limits: 5000/hr authenticated (the `GITHUB_TOKEN`/gh-auth flow already in place handles this). Not a concern in practice.

## Offline

If ResolveRevision fails (network down, permission denied, endpoint 5xx), the resolver falls back to re-fetch — which also fails on no-network, so sync errors. This is a real regression vs pre-#46 behaviour where pin-to-tag users could sync entirely offline from cache. Mitigation: the existing `--offline` CLI flag could be wired through to skip SHA revalidation (trust the cache unconditionally). Out of scope for this PR — simple follow-up if anyone asks for it.

## Tests

`TestResolver_MutableRefSHARevalidation` — 9 subtests covering the full decision matrix:

- [x] `matching_SHA_keeps_cache_(no_Fetch,_one_ResolveRevision)` — empty-ref hit
- [x] `mismatched_SHA_forces_re-fetch_and_records_new_revision`
- [x] `missing_prior_revision_falls_back_to_re-fetch_(backward_compat_with_pre-revision_lockfiles)`
- [x] `fetcher_without_RevisionResolver_falls_back_to_re-fetch`
- [x] `ResolveRevision_error_falls_back_to_re-fetch`
- [x] `pinned_tag_with_matching_SHA_reuses_cache_(uniform_SHA_path)` — NEW
- [x] `moved_tag_triggers_refetch_(uniform_SHA_path_catches_bad-practice_tag_rewrites)` — NEW
- [x] `branch_ref_@main_with_matching_SHA_reuses_cache_(the_whole_point_of_going_uniform)` — NEW
- [x] `branch_ref_@main_with_moved_SHA_refetches` — NEW

Plus updated `TestResolver_EmptyRefBypassesCache/pinned_tag_without_prior_revision_refetches` to cover the migration path from pre-revision lockfiles.

Full suite: `go test ./...` green. Lint pre-push hook: `0 issues ✅`.

## Manual verification plan

- [x] Fresh sync in a workspace with `source: github:org/repo` — tarball fetched, revision recorded in lockfile.
- [x] Second sync, no upstream change — single HEAD API call, no archive download, `.claude/skills/` unchanged.
- [x] Push a commit to upstream default branch, run `devrune sync` — HEAD API call detects SHA change, archive re-fetched, `.claude/skills/` reflects new content.
- [x] Same three checks for `@main` pinning — now covered by the uniform path.
- [ ] `@v1.0.0` pinning — one HEAD call per sync, no archive refetch unless tag moved.