### PR TITLE
fix(materialize): finish adviser→advisor rename + skip REGISTRY variants

### DIFF
--- a/internal/materialize/renderers/claude.go
+++ b/internal/materialize/renderers/claude.go
@@ -403,7 +403,9 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 	// Remove _shared/ files that the Claude-native orchestrator does not reference.
 	// launch-templates.md is now installed from launch-templates.claude.md (variant suffix
 	// stripped) and IS referenced by ORCHESTRATOR.claude.md — do NOT remove it.
-	// adviser-templates.md is only needed by Codex/Factory via the generic ORCHESTRATOR.md.
+	// advisor-templates.md is only needed by Codex/Factory via the generic ORCHESTRATOR.md.
+	_ = os.Remove(filepath.Join(destBase, "_shared", "advisor-templates.md"))
+	// Also remove the legacy filename if present (one-release transition shim).
 	_ = os.Remove(filepath.Join(destBase, "_shared", "adviser-templates.md"))
 
 	// 5. If the entrypoint was not present in the cache directory (cache lacks the
@@ -613,8 +615,8 @@ func (r *ClaudeRenderer) generateSubAgentFile(
 // so emitting it enforces read-only behavior. The `skills:` field preloads the
 // advisor skill body, so the agent file itself stays under 1 KB.
 //
-// Model resolves via the {WORKFLOW_MODEL_ADVISER} placeholder emitted by the
-// sentinel `sdd-adviser` role in workflow.yaml (substituted by postProcessWorkflow
+// Model resolves via the {WORKFLOW_MODEL_ADVISOR} placeholder emitted by the
+// sentinel `sdd-advisor` role in workflow.yaml (substituted by postProcessWorkflow
 // after this helper returns).
 func (r *ClaudeRenderer) generateAdvisorAgentFile(agentsBase string, advisorName string) error {
 	description := skillDescriptionForRole(advisorName)
@@ -629,7 +631,7 @@ func (r *ClaudeRenderer) generateAdvisorAgentFile(agentsBase string, advisorName
 		"skills":                   []string{advisorName},
 		"permissionMode":           "default",
 		"disable-model-invocation": false,
-		"model":                    "{WORKFLOW_MODEL_ADVISER}",
+		"model":                    "{WORKFLOW_MODEL_ADVISOR}",
 	}
 
 	tools := claudeSubAgentTools[advisorName]
@@ -659,12 +661,13 @@ func (r *ClaudeRenderer) generateAdvisorAgentFile(agentsBase string, advisorName
 }
 
 // postProcessWorkflow runs post-installation processing on a workflow's rendered files.
-// T017: For SKILL.md files containing <!-- ADVISER_TABLE_PLACEHOLDER -->, replaces it
-// with a markdown table of installed advisor skills. For ALL .md files (including
-// ORCHESTRATOR.md), resolves shared placeholders ({SKILLS_PATH}, {SDD_MODEL_*}).
+// T017: For SKILL.md files containing <!-- ADVISOR_TABLE_PLACEHOLDER --> (or its
+// legacy ADVISER_TABLE_PLACEHOLDER alias), replaces it with a markdown table of
+// installed advisor skills. For ALL .md files (including ORCHESTRATOR.md),
+// resolves shared placeholders ({SKILLS_PATH}, {SDD_MODEL_*}).
 func (r *ClaudeRenderer) postProcessWorkflow(destBase string, replacements map[string]string) error {
 	// Build the advisor table from installed skills whose names contain "advisor" or "adviser".
-	adviserTable := r.buildAdviserTable()
+	advisorTable := r.buildAdvisorTable()
 
 	// Walk all .md files under destBase and apply replacements.
 	return filepath.WalkDir(destBase, func(path string, d os.DirEntry, walkErr error) error {
@@ -694,15 +697,18 @@ func (r *ClaudeRenderer) postProcessWorkflow(destBase string, replacements map[s
 			}
 		}
 
-		// Replace <!-- ADVISER_TABLE_PLACEHOLDER --> only in SKILL.md files.
-		if d.Name() == "SKILL.md" && strings.Contains(content, "<!-- ADVISER_TABLE_PLACEHOLDER -->") {
-			if adviserTable == "" {
-				// No advisor skills installed — log warning but don't fail.
-				content = strings.ReplaceAll(content, "<!-- ADVISER_TABLE_PLACEHOLDER -->", "")
-			} else {
-				content = strings.ReplaceAll(content, "<!-- ADVISER_TABLE_PLACEHOLDER -->", adviserTable)
+		// Replace <!-- ADVISOR_TABLE_PLACEHOLDER --> (and legacy ADVISER_ alias) only in SKILL.md files.
+		if d.Name() == "SKILL.md" {
+			for _, marker := range []string{"<!-- ADVISOR_TABLE_PLACEHOLDER -->", "<!-- ADVISER_TABLE_PLACEHOLDER -->"} {
+				if strings.Contains(content, marker) {
+					if advisorTable == "" {
+						content = strings.ReplaceAll(content, marker, "")
+					} else {
+						content = strings.ReplaceAll(content, marker, advisorTable)
+					}
+					modified = true
+				}
 			}
-			modified = true
 		}
 
 		if modified {
@@ -714,23 +720,23 @@ func (r *ClaudeRenderer) postProcessWorkflow(destBase string, replacements map[s
 	})
 }
 
-// buildAdviserTable creates a markdown table of installed advisor skills.
-// Advisor skills are those whose Name contains "adviser" or "advisor".
-func (r *ClaudeRenderer) buildAdviserTable() string {
-	var advisers []model.ContentItem
+// buildAdvisorTable creates a markdown table of installed advisor skills.
+// Advisor skills are those whose Name contains "advisor" (or the legacy "adviser" alias).
+func (r *ClaudeRenderer) buildAdvisorTable() string {
+	var advisors []model.ContentItem
 	for _, skill := range r.installedSkills {
-		if strings.Contains(skill.Name, "adviser") || strings.Contains(skill.Name, "advisor") {
-			advisers = append(advisers, skill)
+		if strings.Contains(skill.Name, "advisor") || strings.Contains(skill.Name, "adviser") {
+			advisors = append(advisors, skill)
 		}
 	}
-	if len(advisers) == 0 {
+	if len(advisors) == 0 {
 		return ""
 	}
 
 	var sb strings.Builder
 	sb.WriteString("| Skill | Invocation | Use When |\n")
 	sb.WriteString("|-------|------------|----------|\n")
-	for _, a := range advisers {
+	for _, a := range advisors {
 		_, _ = fmt.Fprintf(&sb, "| `%s` | `/%s` | %s |\n", a.Name, a.Name, a.Description)
 	}
 	return sb.String()

--- a/internal/materialize/renderers/codex.go
+++ b/internal/materialize/renderers/codex.go
@@ -256,6 +256,12 @@ func (r *CodexRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath str
 			continue
 		}
 
+		// Skip all registry variant files — only the renderer whose variant matches
+		// consumes it; never copied loose into the workspace.
+		if registryVariantNames[name] {
+			continue
+		}
+
 		// Skip all orchestrator variant files — none should be copied as loose files.
 		// Codex uses the generic ORCHESTRATOR.md entrypoint; agent-specific variants
 		// are for OpenCode and Copilot only.

--- a/internal/materialize/renderers/copilot.go
+++ b/internal/materialize/renderers/copilot.go
@@ -467,6 +467,12 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 			continue
 		}
 
+		// Skip all registry variant files — only the renderer whose variant matches
+		// consumes it; never copied loose into the workspace.
+		if registryVariantNames[name] {
+			continue
+		}
+
 		// Skip all orchestrator variant files — none should be copied as loose files.
 		// Each renderer uses only its own variant (resolved in the pre-loop probe above).
 		if orchestratorVariantNames[name] {

--- a/internal/materialize/renderers/factory.go
+++ b/internal/materialize/renderers/factory.go
@@ -265,6 +265,12 @@ func (r *FactoryRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 			continue
 		}
 
+		// Skip all registry variant files — only the renderer whose variant matches
+		// consumes it; never copied loose into the workspace.
+		if registryVariantNames[name] {
+			continue
+		}
+
 		// Skip all orchestrator variant files — none should be copied as loose files.
 		// Factory uses the generic ORCHESTRATOR.md entrypoint; agent-specific variants
 		// are for OpenCode and Copilot only.

--- a/internal/materialize/renderers/helpers.go
+++ b/internal/materialize/renderers/helpers.go
@@ -28,6 +28,18 @@ var orchestratorVariantNames = map[string]bool{
 	"ORCHESTRATOR.claude.md":   true,
 }
 
+// registryVariantNames is the set of agent-specific registry variant filenames.
+// Like orchestrator variants, these must NEVER be copied as loose files into the
+// workspace — each renderer only consumes its own variant (via captureRegistryContent)
+// and the rest are skipped by the generic scan loop.
+var registryVariantNames = map[string]bool{
+	"REGISTRY.opencode.md": true,
+	"REGISTRY.copilot.md":  true,
+	"REGISTRY.claude.md":   true,
+	"REGISTRY.codex.md":    true,
+	"REGISTRY.factory.md":  true,
+}
+
 // hookAssetDirNames lists workflow cache directories that contain hook/plugin
 // assets. These are NOT copied by the generic "everything else" loop — they are
 // only installed by the renderer whose agent is explicitly declared in
@@ -764,6 +776,7 @@ func buildWorkflowPlaceholderReplacements(
 		"PLANNER":     "{SDD_MODEL_PLAN}",
 		"IMPLEMENTER": "{SDD_MODEL_IMPLEMENT}",
 		"REVIEWER":    "{SDD_MODEL_REVIEW}",
+		"ADVISOR":     "{SDD_MODEL_ADVISOR}",
 		"ADVISER":     "{SDD_MODEL_ADVISER}",
 	}
 
@@ -1111,20 +1124,20 @@ func skillDescriptionForRole(skill string) string {
 		return "SDD Implement sub-agent"
 	case "sdd-review":
 		return "SDD Review sub-agent"
-	case "architect-adviser", "architect-advisor":
-		return "Clean architecture adviser: hexagonal, DDD, ports and adapters"
-	case "api-first-adviser", "api-first-advisor":
-		return "API-first design adviser: OpenAPI, REST conventions, error models"
-	case "unit-test-adviser", "unit-test-advisor":
-		return "Unit test adviser: test structure, mocking, Given-When-Then"
-	case "integration-test-adviser", "integration-test-advisor":
-		return "Integration test adviser: adapter testing, external service mocking"
-	case "component-adviser", "component-advisor":
-		return "React component adviser: composition, hooks, state management"
-	case "frontend-test-adviser", "frontend-test-advisor":
-		return "Frontend test adviser: React Testing Library, Vitest, Cypress"
-	case "web-accessibility-adviser", "web-accessibility-advisor":
-		return "Web accessibility adviser: WCAG 2.1 AA, ARIA, keyboard navigation"
+	case "architect-advisor", "architect-adviser":
+		return "Clean architecture advisor: hexagonal, DDD, ports and adapters"
+	case "api-first-advisor", "api-first-adviser":
+		return "API-first design advisor: OpenAPI, REST conventions, error models"
+	case "unit-test-advisor", "unit-test-adviser":
+		return "Unit test advisor: test structure, mocking, Given-When-Then"
+	case "integration-test-advisor", "integration-test-adviser":
+		return "Integration test advisor: adapter testing, external service mocking"
+	case "component-advisor", "component-adviser":
+		return "React component advisor: composition, hooks, state management"
+	case "frontend-test-advisor", "frontend-test-adviser":
+		return "Frontend test advisor: React Testing Library, Vitest, Cypress"
+	case "web-accessibility-advisor", "web-accessibility-adviser":
+		return "Web accessibility advisor: WCAG 2.1 AA, ARIA, keyboard navigation"
 	default:
 		return skill + " sub-agent"
 	}

--- a/internal/materialize/renderers/opencode.go
+++ b/internal/materialize/renderers/opencode.go
@@ -322,6 +322,12 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 			continue
 		}
 
+		// Skip all registry variant files (e.g. REGISTRY.claude.md) — only the renderer
+		// whose variant matches uses it, never copied loose into the workspace.
+		if registryVariantNames[name] {
+			continue
+		}
+
 		// Skip all orchestrator variant files — none should be copied as loose files.
 		// Each renderer uses only its own variant (resolved in the pre-loop probe above).
 		if orchestratorVariantNames[name] {

--- a/internal/tui/steps/workflow_models.go
+++ b/internal/tui/steps/workflow_models.go
@@ -907,7 +907,7 @@ func RunWorkflowModelSelection(
 	// (model selection runs before the scan step): synthesize the canonical SDD
 	// subagent role list so the form always shows on first install.
 	if len(roles) == 0 && sddAutoSelected && len(savedModels) == 0 {
-		for _, roleName := range []string{"sdd-explorer", "sdd-planner", "sdd-implementer", "sdd-reviewer", "sdd-adviser", "sdd-advisor"} {
+		for _, roleName := range []string{"sdd-explorer", "sdd-planner", "sdd-implementer", "sdd-reviewer", "sdd-advisor"} {
 			roles = append(roles, model.WorkflowRole{
 				Name:  roleName,
 				Kind:  "subagent",


### PR DESCRIPTION
## Summary

Two bugs surfaced when reinstalling against the catalog after the adviser→advisor migration in [devrune-starter-catalog#17](https://github.com/davidarce/devrune-starter-catalog/pull/17):

1. **Duplicate Adviser/Advisor row in Step 3/7 (Workflow Models).** `internal/tui/steps/workflow_models.go` hard-coded both legacy and new role names when synthesising the SDD role list before any workflow manifest had been loaded.
2. **`REGISTRY.claude.md` leaking into non-Claude workspaces.** OpenCode, Codex, Factory and Copilot scan loops only suppressed the generic `REGISTRY.md`, so any agent-specific variant (e.g. `REGISTRY.claude.md`) was copied as a loose file into the wrong workspace. Each renderer should consume only its own variant — the same contract that already existed for orchestrator variants.

## Changes

- `internal/tui/steps/workflow_models.go`: drop `sdd-adviser` from the canonical synthesised role list; only `sdd-advisor` remains.
- `internal/materialize/renderers/helpers.go`:
  - Introduce `registryVariantNames` set (`REGISTRY.{claude,opencode,copilot,codex,factory}.md`), mirroring the existing `orchestratorVariantNames`.
  - Add `ADVISOR` → `{SDD_MODEL_ADVISOR}` legacy alias alongside the kept `ADVISER` shim in the SDD legacy placeholder map.
  - Update `skillDescriptionForRole` description strings to use "advisor" wording (case keys keep both suffixes for compat).
- `internal/materialize/renderers/{opencode,codex,factory,copilot}.go`: skip `registryVariantNames[name]` in the install scan loop, immediately after the generic-registry skip.
- `internal/materialize/renderers/claude.go`:
  - Emit `{WORKFLOW_MODEL_ADVISOR}` (was `ADVISER`) in synthesised advisor wrapper frontmatter.
  - Rename `buildAdviserTable` → `buildAdvisorTable`.
  - `postProcessWorkflow` accepts both `<!-- ADVISOR_TABLE_PLACEHOLDER -->` and the legacy `<!-- ADVISER_TABLE_PLACEHOLDER -->` markers.
  - Clean both `advisor-templates.md` and the legacy `adviser-templates.md` from `_shared/` for the Claude variant (Claude doesn't reference them; only Codex/Factory/OpenCode/Copilot do).

## Compat shims (kept for one-release transition)

- `<!-- ADVISER_TABLE_PLACEHOLDER -->` continues to be replaced.
- `modelOverrides["sdd-adviser"]` fallback in `copilot.go`.
- `*-adviser` suffix continues to match in advisor wrapper synthesis.
- `SDD_MODEL_ADVISER` legacy placeholder still emitted for old role names.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/materialize/... ./internal/tui/...` (all pass)
- [ ] Clear cache (`~/Library/Caches/devrune/packages/`) and reinstall against the catalog merged from devrune-starter-catalog#17 + #18
- [ ] Confirm Step 3/7 shows a single **Advisor** row
- [ ] Confirm `.opencode/opencode.json` has `sdd-advisor` (not `sdd-adviser`)
- [ ] Confirm `.opencode/sdd-orchestrator/`, `.github/`, `.factory/`, `.codex/` do not contain `REGISTRY.claude.md`
- [ ] Confirm no `*-adviser` directories or content remain in any agent workspace

> Note for reviewers: the `TestReservedAdvisorNamesMatchesDisk` test in `internal/advisormeta` may fail locally if `.claude/skills/*-advisor/SKILL.md` are not present in the working copy (e.g. after a `devrune uninstall` on the dogfooded repo). This is a pre-existing condition unrelated to this PR — CI will pass because the repo state in CI carries those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)