### PR TITLE
chore(advisors): remove adviser→advisor compat shims

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -63,13 +63,13 @@ Automate git commits following Conventional Commits specification.
 		t.Fatalf("write SKILL.md: %v", err)
 	}
 
-	// Skill: architect-adviser
-	architectDir := filepath.Join(pkgContent, "skills", "architect-adviser")
+	// Skill: architect-advisor
+	architectDir := filepath.Join(pkgContent, "skills", "architect-advisor")
 	if err := os.MkdirAll(architectDir, 0o755); err != nil {
 		t.Fatalf("mkdir skill: %v", err)
 	}
 	architectSkill := `---
-name: architect-adviser
+name: architect-advisor
 description: "Clean architecture patterns: hexagonal, DDD, ports and adapters."
 allowed-tools:
   - Read
@@ -77,7 +77,7 @@ allowed-tools:
 model: sonnet
 ---
 
-# architect-adviser Skill
+# architect-advisor Skill
 
 Provides clean architecture guidance.
 `
@@ -242,7 +242,7 @@ Create a detailed implementation plan.
 		}
 	}
 	if len(skillNames) != 2 {
-		t.Errorf("skills = %v, want 2 skills (git-commit, architect-adviser)", skillNames)
+		t.Errorf("skills = %v, want 2 skills (git-commit, architect-advisor)", skillNames)
 	}
 	if len(ruleNames) != 1 {
 		t.Errorf("rules = %v, want 1 rule", ruleNames)
@@ -317,10 +317,10 @@ Create a detailed implementation plan.
 		t.Errorf("git-commit/SKILL.md not installed: %v", err)
 	}
 
-	// architect-adviser skill must have SKILL.md.
-	architectInstalled := filepath.Join(skillsDir, "architect-adviser", "SKILL.md")
+	// architect-advisor skill must have SKILL.md.
+	architectInstalled := filepath.Join(skillsDir, "architect-advisor", "SKILL.md")
 	if _, err := os.Stat(architectInstalled); err != nil {
-		t.Errorf("architect-adviser/SKILL.md not installed: %v", err)
+		t.Errorf("architect-advisor/SKILL.md not installed: %v", err)
 	}
 
 	// Installed SKILL.md should have correct frontmatter (name field present).
@@ -444,11 +444,11 @@ func TestE2E_PackageOnly(t *testing.T) {
 
 	// Create fixture package with a single skill.
 	pkgDir := filepath.Join(projectRoot, "fixtures", "simple-pkg")
-	skillDir := filepath.Join(pkgDir, "skills", "unit-test-adviser")
+	skillDir := filepath.Join(pkgDir, "skills", "unit-test-advisor")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatalf("mkdir skill: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: unit-test-adviser\ndescription: Unit test guidance.\n---\n# Unit Test Adviser\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: unit-test-advisor\ndescription: Unit test guidance.\n---\n# Unit Test Adviser\n"), 0o644); err != nil {
 		t.Fatalf("write SKILL.md: %v", err)
 	}
 
@@ -504,12 +504,12 @@ func TestE2E_PackageOnly(t *testing.T) {
 		t.Fatalf("install: %v", err)
 	}
 
-	installed := filepath.Join(projectRoot, ".claude", "skills", "unit-test-adviser", "SKILL.md")
+	installed := filepath.Join(projectRoot, ".claude", "skills", "unit-test-advisor", "SKILL.md")
 	data, err := os.ReadFile(installed)
 	if err != nil {
 		t.Fatalf("read installed skill: %v", err)
 	}
-	if !strings.Contains(string(data), "unit-test-adviser") {
+	if !strings.Contains(string(data), "unit-test-advisor") {
 		t.Errorf("installed skill missing name, content:\n%s", data)
 	}
 }

--- a/internal/cli/sdd_advisors.go
+++ b/internal/cli/sdd_advisors.go
@@ -21,12 +21,10 @@ import (
 )
 
 // newSddAdvisorsCmd constructs the "sdd-advisors" Cobra subcommand.
-// An alias "sdd-advisers" is registered for one-release backward compat.
 func newSddAdvisorsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "sdd-advisors",
-		Aliases: []string{"sdd-advisers"},
-		Short:   "Manage SDD advisors — list, install, uninstall, and register custom advisors",
+		Use:   "sdd-advisors",
+		Short: "Manage SDD advisors — list, install, uninstall, and register custom advisors",
 		Long: `Manage SDD advisors interactively or via flags.
 
 devrune sdd-advisors provides a TUI to list, toggle (install/uninstall),
@@ -64,10 +62,7 @@ Examples:
   devrune sdd-advisors --refresh-catalogs
 
   Note: --refresh-catalogs returns an error if any source fetch fails.
-  All sources are attempted; per-source errors are aggregated and reported together.
-
-  Note: the alias 'sdd-advisers' (British spelling) is accepted for one
-  release as a backward-compat shim and will be removed in a future version.`,
+  All sources are attempted; per-source errors are aggregated and reported together.`,
 		RunE:          runSddAdvisors,
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/internal/materialize/advisor_renderer.go
+++ b/internal/materialize/advisor_renderer.go
@@ -17,13 +17,7 @@ import (
 //
 // Detection rule (applied identically by every implementing renderer):
 //
-//	hasAdvisorSuffix := strings.HasSuffix(strings.ToLower(item.Name), "-advisor")
-//	hasLegacySuffix  := strings.HasSuffix(strings.ToLower(item.Name), "-adviser") // compat shim
-//	isAdvisor        := hasAdvisorSuffix || hasLegacySuffix || item.Custom
-//
-// The legacy "-adviser" branch is gated behind a log-once deprecation warning
-// (via log.Printf on first detection per process) and will be removed in the
-// next minor release.
+//	isAdvisor := strings.HasSuffix(strings.ToLower(item.Name), "-advisor") || item.Custom
 //
 // Statelessness requirement: RegenerateAdvisorFiles MUST be stateless on the
 // receiver. Two consecutive calls with different installed sets MUST NOT leak

--- a/internal/materialize/materializer_test.go
+++ b/internal/materialize/materializer_test.go
@@ -465,16 +465,16 @@ func TestMaterializer_Install_CallsRenderSettings(t *testing.T) {
 
 // TestMaterializer_Install_SetsInstalledSkillsBeforeWorkflow verifies that the
 // materializer calls SetInstalledSkills on the renderer before InstallWorkflow,
-// so that workflow post-processing (adviser table injection) can use them.
+// so that workflow post-processing (advisor table injection) can use them.
 func TestMaterializer_Install_SetsInstalledSkillsBeforeWorkflow(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create a fake skill package in the cache.
 	skillPkgDir := t.TempDir()
-	skillDir := filepath.Join(skillPkgDir, "skills", "architect-adviser")
+	skillDir := filepath.Join(skillPkgDir, "skills", "architect-advisor")
 	_ = os.MkdirAll(skillDir, 0o755)
 	_ = os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
-		[]byte("---\nname: architect-adviser\ndescription: Architecture advice\n---\nBody.\n"), 0o644)
+		[]byte("---\nname: architect-advisor\ndescription: Architecture advice\n---\nBody.\n"), 0o644)
 
 	// Create a fake workflow in the cache.
 	wfDir := t.TempDir()
@@ -513,7 +513,7 @@ components:
 			{
 				Hash: skillHash,
 				Contents: []model.ContentItem{
-					{Kind: model.KindSkill, Name: "architect-adviser", Path: "skills/architect-adviser"},
+					{Kind: model.KindSkill, Name: "architect-advisor", Path: "skills/architect-advisor"},
 				},
 			},
 		},
@@ -530,9 +530,9 @@ components:
 	if len(renderer.setInstalledSkills) != 1 {
 		t.Errorf("SetInstalledSkills received %d skills, want 1", len(renderer.setInstalledSkills))
 	}
-	if len(renderer.setInstalledSkills) > 0 && renderer.setInstalledSkills[0].Name != "architect-adviser" {
+	if len(renderer.setInstalledSkills) > 0 && renderer.setInstalledSkills[0].Name != "architect-advisor" {
 		t.Errorf("setInstalledSkills[0].Name = %q, want %q",
-			renderer.setInstalledSkills[0].Name, "architect-adviser")
+			renderer.setInstalledSkills[0].Name, "architect-advisor")
 	}
 }
 
@@ -1212,10 +1212,10 @@ func TestMaterializer_Install_RootCatalogContainsSkillNames(t *testing.T) {
 
 	// Create a fake skill package in the cache.
 	pkgDir := t.TempDir()
-	skillDir := filepath.Join(pkgDir, "skills", "unit-test-adviser")
+	skillDir := filepath.Join(pkgDir, "skills", "unit-test-advisor")
 	_ = os.MkdirAll(skillDir, 0o755)
 	_ = os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
-		[]byte("---\nname: unit-test-adviser\ndescription: Domain unit test patterns\n---\nBody.\n"), 0o644)
+		[]byte("---\nname: unit-test-advisor\ndescription: Domain unit test patterns\n---\nBody.\n"), 0o644)
 
 	cache := newStubCache()
 	pkgHash := "sha256:skill-catalog-test"
@@ -1241,7 +1241,7 @@ func TestMaterializer_Install_RootCatalogContainsSkillNames(t *testing.T) {
 			{
 				Hash: pkgHash,
 				Contents: []model.ContentItem{
-					{Kind: model.KindSkill, Name: "unit-test-adviser", Path: "skills/unit-test-adviser", Description: "Domain unit test patterns"},
+					{Kind: model.KindSkill, Name: "unit-test-advisor", Path: "skills/unit-test-advisor", Description: "Domain unit test patterns"},
 				},
 			},
 		},
@@ -1258,8 +1258,8 @@ func TestMaterializer_Install_RootCatalogContainsSkillNames(t *testing.T) {
 	}
 	content := string(data)
 
-	if !strings.Contains(content, "unit-test-adviser") {
-		t.Errorf("AGENTS.md should contain skill name 'unit-test-adviser'; got:\n%s", content)
+	if !strings.Contains(content, "unit-test-advisor") {
+		t.Errorf("AGENTS.md should contain skill name 'unit-test-advisor'; got:\n%s", content)
 	}
 }
 
@@ -1428,12 +1428,12 @@ func TestMaterializer_Install_SkillDeduplication_SharedDirRenderedOnce(t *testin
 
 	// Create a fake skill package in the cache.
 	pkgDir := t.TempDir()
-	skillSubDir := filepath.Join(pkgDir, "skills", "unit-test-adviser")
+	skillSubDir := filepath.Join(pkgDir, "skills", "unit-test-advisor")
 	if err := os.MkdirAll(skillSubDir, 0o755); err != nil {
 		t.Fatalf("mkdir skill dir: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(skillSubDir, "SKILL.md"),
-		[]byte("---\nname: unit-test-adviser\ndescription: Domain unit tests\n---\nBody.\n"), 0o644); err != nil {
+		[]byte("---\nname: unit-test-advisor\ndescription: Domain unit tests\n---\nBody.\n"), 0o644); err != nil {
 		t.Fatalf("write SKILL.md: %v", err)
 	}
 
@@ -1458,7 +1458,7 @@ func TestMaterializer_Install_SkillDeduplication_SharedDirRenderedOnce(t *testin
 			{
 				Hash: pkgHash,
 				Contents: []model.ContentItem{
-					{Kind: model.KindSkill, Name: "unit-test-adviser", Path: "skills/unit-test-adviser"},
+					{Kind: model.KindSkill, Name: "unit-test-advisor", Path: "skills/unit-test-advisor"},
 				},
 			},
 		},
@@ -1496,15 +1496,15 @@ func TestMaterializer_Install_SkillDeduplication_SharedDirRenderedOnce(t *testin
 	}
 
 	// The skill file must exist in .agents/skills/ (written by whichever renderer won).
-	skillPath := filepath.Join(agentsSkillsDir, "unit-test-adviser", "SKILL.md")
+	skillPath := filepath.Join(agentsSkillsDir, "unit-test-advisor", "SKILL.md")
 	if _, err := os.Stat(skillPath); err != nil {
-		t.Errorf("skill file should exist in .agents/skills/unit-test-adviser/SKILL.md: %v", err)
+		t.Errorf("skill file should exist in .agents/skills/unit-test-advisor/SKILL.md: %v", err)
 	}
 
 	// The skill file must also exist in .claude/skills/.
-	claudeSkillPath := filepath.Join(claudeWorkspace, "skills", "unit-test-adviser", "SKILL.md")
+	claudeSkillPath := filepath.Join(claudeWorkspace, "skills", "unit-test-advisor", "SKILL.md")
 	if _, err := os.Stat(claudeSkillPath); err != nil {
-		t.Errorf("skill file should exist in .claude/skills/unit-test-adviser/SKILL.md: %v", err)
+		t.Errorf("skill file should exist in .claude/skills/unit-test-advisor/SKILL.md: %v", err)
 	}
 }
 

--- a/internal/materialize/renderers/catalog_test.go
+++ b/internal/materialize/renderers/catalog_test.go
@@ -48,7 +48,7 @@ func TestRenderRootCatalog_EmptyInputs(t *testing.T) {
 func TestRenderRootCatalog_WithSkills(t *testing.T) {
 	skills := []model.ContentItem{
 		{Kind: model.KindSkill, Name: "git-commit", Path: "skills/git-commit/", Description: "Automate git commits"},
-		{Kind: model.KindSkill, Name: "architect-adviser", Path: "skills/architect-adviser/", Description: "Clean architecture patterns"},
+		{Kind: model.KindSkill, Name: "architect-advisor", Path: "skills/architect-advisor/", Description: "Clean architecture patterns"},
 	}
 
 	out, err := renderers.RenderRootCatalog(skills, nil, nil, nil, nil)
@@ -71,8 +71,8 @@ func TestRenderRootCatalog_WithSkills(t *testing.T) {
 	if !strings.Contains(out, "Automate git commits") {
 		t.Errorf("output missing skill description")
 	}
-	if !strings.Contains(out, "`architect-adviser`") {
-		t.Errorf("output missing architect-adviser skill row")
+	if !strings.Contains(out, "`architect-advisor`") {
+		t.Errorf("output missing architect-advisor skill row")
 	}
 }
 
@@ -87,7 +87,7 @@ func TestRenderRootCatalog_WithRules(t *testing.T) {
 			RuleMeta: &model.RuleMeta{
 				Scope:       "architecture",
 				Technology:  "",
-				AppliesTo:   "architect-adviser",
+				AppliesTo:   "architect-advisor",
 				Description: "Hexagonal architecture, DDD patterns",
 				DisplayName: "clean-architecture",
 			},
@@ -100,7 +100,7 @@ func TestRenderRootCatalog_WithRules(t *testing.T) {
 			RuleMeta: &model.RuleMeta{
 				Scope:      "tech",
 				Technology: "java",
-				AppliesTo:  "architect-adviser, unit-test-adviser",
+				AppliesTo:  "architect-advisor, unit-test-advisor",
 			},
 		},
 	}

--- a/internal/materialize/renderers/claude.go
+++ b/internal/materialize/renderers/claude.go
@@ -9,20 +9,14 @@ package renderers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/davidarce/devrune/internal/materialize/matypes"
 	"github.com/davidarce/devrune/internal/model"
 	"github.com/davidarce/devrune/internal/parse"
 )
-
-// deprecateAdviserSuffixOnce gates the one-time deprecation log emitted when
-// RegenerateAdvisorFiles encounters a legacy "-adviser" suffix item.
-var deprecateAdviserSuffixOnce sync.Once
 
 // claudeDropFields lists frontmatter fields that Claude does not use and should be stripped.
 // Claude's format is the canonical format, so most fields pass through unchanged.
@@ -46,25 +40,16 @@ var claudeDropFields = []string{
 // what the skill body invokes; duplicating that list here would drift as skills
 // evolve without adding restriction value (phases legitimately need broad access).
 //
-// ADVISER/ADVISOR sub-agents ARE listed because Read/Grep/Glob is STRICTER than the
+// ADVISOR sub-agents ARE listed because Read/Grep/Glob is STRICTER than the
 // parent's allowlist; the explicit `tools:` field enforces read-only behavior.
-// Both -adviser (legacy) and -advisor (new) keys are kept during the transition
-// period until T040 renames the installed skill directories.
 var claudeSubAgentTools = map[string][]string{
-	"architect-adviser":          {"Read", "Grep", "Glob"},
-	"architect-advisor":          {"Read", "Grep", "Glob"},
-	"api-first-adviser":          {"Read", "Grep", "Glob"},
-	"api-first-advisor":          {"Read", "Grep", "Glob"},
-	"unit-test-adviser":          {"Read", "Grep", "Glob"},
-	"unit-test-advisor":          {"Read", "Grep", "Glob"},
-	"integration-test-adviser":   {"Read", "Grep", "Glob"},
-	"integration-test-advisor":   {"Read", "Grep", "Glob"},
-	"component-adviser":          {"Read", "Grep", "Glob"},
-	"component-advisor":          {"Read", "Grep", "Glob"},
-	"frontend-test-adviser":      {"Read", "Grep", "Glob"},
-	"frontend-test-advisor":      {"Read", "Grep", "Glob"},
-	"web-accessibility-adviser":  {"Read", "Grep", "Glob"},
-	"web-accessibility-advisor":  {"Read", "Grep", "Glob"},
+	"architect-advisor":         {"Read", "Grep", "Glob"},
+	"api-first-advisor":         {"Read", "Grep", "Glob"},
+	"unit-test-advisor":         {"Read", "Grep", "Glob"},
+	"integration-test-advisor":  {"Read", "Grep", "Glob"},
+	"component-advisor":         {"Read", "Grep", "Glob"},
+	"frontend-test-advisor":     {"Read", "Grep", "Glob"},
+	"web-accessibility-advisor": {"Read", "Grep", "Glob"},
 }
 
 // claudeSubAgentMCPServers defines the `mcpServers:` frontmatter list per
@@ -77,24 +62,17 @@ var claudeSubAgentTools = map[string][]string{
 //     and sdd-review SKILL.md bodies do NOT reference Atlassian, so they do NOT
 //     receive it.
 var claudeSubAgentMCPServers = map[string][]string{
-	"sdd-explore":                {"engram", "atlassian"},
-	"sdd-plan":                   {"engram"},
-	"sdd-implement":              {"engram"},
-	"sdd-review":                 {"engram"},
-	"architect-adviser":          {"engram"},
-	"architect-advisor":          {"engram"},
-	"api-first-adviser":          {"engram"},
-	"api-first-advisor":          {"engram"},
-	"unit-test-adviser":          {"engram"},
-	"unit-test-advisor":          {"engram"},
-	"integration-test-adviser":   {"engram"},
-	"integration-test-advisor":   {"engram"},
-	"component-adviser":          {"engram"},
-	"component-advisor":          {"engram"},
-	"frontend-test-adviser":      {"engram"},
-	"frontend-test-advisor":      {"engram"},
-	"web-accessibility-adviser":  {"engram"},
-	"web-accessibility-advisor":  {"engram"},
+	"sdd-explore":               {"engram", "atlassian"},
+	"sdd-plan":                  {"engram"},
+	"sdd-implement":             {"engram"},
+	"sdd-review":                {"engram"},
+	"architect-advisor":         {"engram"},
+	"api-first-advisor":         {"engram"},
+	"unit-test-advisor":         {"engram"},
+	"integration-test-advisor":  {"engram"},
+	"component-advisor":         {"engram"},
+	"frontend-test-advisor":     {"engram"},
+	"web-accessibility-advisor": {"engram"},
 }
 
 // ClaudeRenderer materializes skills, commands, MCPs, and catalog entries for
@@ -278,7 +256,7 @@ func (r *ClaudeRenderer) MCPAgentInstructions() map[string]string {
 //     ORCHESTRATOR.claude.md is preferred when present in the cache; suffix is stripped
 //     at write time so the destination filename remains wf.Components.Entrypoint)
 //   - .claude/agents/{role-name}.md for every subagent role in workflow.yaml
-//   - .claude/agents/{advisor-name}.md for every installed `*-advisor` or `*-adviser` skill
+//   - .claude/agents/{advisor-name}.md for every installed `*-advisor` skill
 //
 // Hook script assets are copied as before; this logic is preserved verbatim.
 // T021: Loads Registry content during installation and stores it for RenderCatalog.
@@ -405,8 +383,6 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 	// stripped) and IS referenced by ORCHESTRATOR.claude.md — do NOT remove it.
 	// advisor-templates.md is only needed by Codex/Factory via the generic ORCHESTRATOR.md.
 	_ = os.Remove(filepath.Join(destBase, "_shared", "advisor-templates.md"))
-	// Also remove the legacy filename if present (one-release transition shim).
-	_ = os.Remove(filepath.Join(destBase, "_shared", "adviser-templates.md"))
 
 	// 5. If the entrypoint was not present in the cache directory (cache lacks the
 	//    generic ORCHESTRATOR.md) but a Claude variant IS present, install the variant
@@ -473,11 +449,10 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 		agentFilePaths = append(agentFilePaths, dstPath)
 	}
 
-	// 7. Synthesize advisor wrapper .md files — one per installed *-advisor or *-adviser skill.
-	//    Both suffixes are checked for transition compat until T040 renames installed skill dirs.
+	// 7. Synthesize advisor wrapper .md files — one per installed *-advisor skill.
 	//    Skip if a file already exists (e.g. generated by the subagent role loop above).
 	for _, skill := range r.installedSkills {
-		if !strings.HasSuffix(skill.Name, "-advisor") && !strings.HasSuffix(skill.Name, "-adviser") {
+		if !strings.HasSuffix(skill.Name, "-advisor") {
 			continue
 		}
 		dstPath := filepath.Join(agentsBase, skill.Name+".md")
@@ -661,12 +636,10 @@ func (r *ClaudeRenderer) generateAdvisorAgentFile(agentsBase string, advisorName
 }
 
 // postProcessWorkflow runs post-installation processing on a workflow's rendered files.
-// T017: For SKILL.md files containing <!-- ADVISOR_TABLE_PLACEHOLDER --> (or its
-// legacy ADVISER_TABLE_PLACEHOLDER alias), replaces it with a markdown table of
-// installed advisor skills. For ALL .md files (including ORCHESTRATOR.md),
-// resolves shared placeholders ({SKILLS_PATH}, {SDD_MODEL_*}).
+// For SKILL.md files containing <!-- ADVISOR_TABLE_PLACEHOLDER -->, replaces it with
+// a markdown table of installed advisor skills. For ALL .md files (including
+// ORCHESTRATOR.md), resolves shared placeholders ({SKILLS_PATH}, {SDD_MODEL_*}).
 func (r *ClaudeRenderer) postProcessWorkflow(destBase string, replacements map[string]string) error {
-	// Build the advisor table from installed skills whose names contain "advisor" or "adviser".
 	advisorTable := r.buildAdvisorTable()
 
 	// Walk all .md files under destBase and apply replacements.
@@ -689,7 +662,6 @@ func (r *ClaudeRenderer) postProcessWorkflow(destBase string, replacements map[s
 		content := string(data)
 		modified := false
 
-		// Resolve all shared placeholders ({SKILLS_PATH}, {SDD_MODEL_*}).
 		for placeholder, value := range replacements {
 			if strings.Contains(content, placeholder) {
 				content = strings.ReplaceAll(content, placeholder, value)
@@ -697,18 +669,10 @@ func (r *ClaudeRenderer) postProcessWorkflow(destBase string, replacements map[s
 			}
 		}
 
-		// Replace <!-- ADVISOR_TABLE_PLACEHOLDER --> (and legacy ADVISER_ alias) only in SKILL.md files.
-		if d.Name() == "SKILL.md" {
-			for _, marker := range []string{"<!-- ADVISOR_TABLE_PLACEHOLDER -->", "<!-- ADVISER_TABLE_PLACEHOLDER -->"} {
-				if strings.Contains(content, marker) {
-					if advisorTable == "" {
-						content = strings.ReplaceAll(content, marker, "")
-					} else {
-						content = strings.ReplaceAll(content, marker, advisorTable)
-					}
-					modified = true
-				}
-			}
+		const advisorTableMarker = "<!-- ADVISOR_TABLE_PLACEHOLDER -->"
+		if d.Name() == "SKILL.md" && strings.Contains(content, advisorTableMarker) {
+			content = strings.ReplaceAll(content, advisorTableMarker, advisorTable)
+			modified = true
 		}
 
 		if modified {
@@ -721,11 +685,11 @@ func (r *ClaudeRenderer) postProcessWorkflow(destBase string, replacements map[s
 }
 
 // buildAdvisorTable creates a markdown table of installed advisor skills.
-// Advisor skills are those whose Name contains "advisor" (or the legacy "adviser" alias).
+// Advisor skills are those whose Name contains "advisor".
 func (r *ClaudeRenderer) buildAdvisorTable() string {
 	var advisors []model.ContentItem
 	for _, skill := range r.installedSkills {
-		if strings.Contains(skill.Name, "advisor") || strings.Contains(skill.Name, "adviser") {
+		if strings.Contains(skill.Name, "advisor") {
 			advisors = append(advisors, skill)
 		}
 	}
@@ -844,11 +808,8 @@ func (r *ClaudeRenderer) Finalize(workspaceRoot string) error { return nil }
 //
 // Detection rule (applied uniformly across all renderers):
 //
-//	hasAdvisorSuffix := strings.HasSuffix(strings.ToLower(item.Name), "-advisor")
-//	hasLegacySuffix  := strings.HasSuffix(strings.ToLower(item.Name), "-adviser") // compat shim
-//	isAdvisor        := hasAdvisorSuffix || hasLegacySuffix || item.Custom
+//	isAdvisor := strings.HasSuffix(strings.ToLower(item.Name), "-advisor") || item.Custom
 //
-// Legacy "-adviser" names emit a one-per-process deprecation log via sync.Once.
 // Non-advisor entries in installed are silently ignored.
 //
 // The method is stateless on the receiver — it does NOT assign installed to
@@ -873,19 +834,9 @@ func (r *ClaudeRenderer) RegenerateAdvisorFiles(
 
 	// Write advisor files for each installed item that passes the detection rule.
 	for _, item := range installed {
-		nameLower := strings.ToLower(item.Name)
-		hasAdvisorSuffix := strings.HasSuffix(nameLower, "-advisor")
-		hasLegacySuffix := strings.HasSuffix(nameLower, "-adviser")
-		isAdvisor := hasAdvisorSuffix || hasLegacySuffix || item.Custom
-
+		isAdvisor := strings.HasSuffix(strings.ToLower(item.Name), "-advisor") || item.Custom
 		if !isAdvisor {
 			continue
-		}
-
-		if hasLegacySuffix && !hasAdvisorSuffix {
-			deprecateAdviserSuffixOnce.Do(func() {
-				log.Printf("DEPRECATION: advisor name %q uses legacy '-adviser' suffix; rename to '-advisor' before next minor release", item.Name)
-			})
 		}
 
 		if err := r.generateAdvisorAgentFile(agentsBase, item.Name); err != nil {

--- a/internal/materialize/renderers/claude_test.go
+++ b/internal/materialize/renderers/claude_test.go
@@ -461,21 +461,21 @@ func TestClaudeRenderer_RenderSettings_DeduplicatesPermissions(t *testing.T) {
 
 // --- T029: Workflow post-processing ---
 
-// TestClaudeRenderer_InstallWorkflow_ReplacesAdviserTablePlaceholder verifies that
-// <!-- ADVISER_TABLE_PLACEHOLDER --> in a SKILL.md is replaced with the adviser skills table.
-func TestClaudeRenderer_InstallWorkflow_ReplacesAdviserTablePlaceholder(t *testing.T) {
+// TestClaudeRenderer_InstallWorkflow_ReplacesAdvisorTablePlaceholder verifies that
+// <!-- ADVISOR_TABLE_PLACEHOLDER --> in a SKILL.md is replaced with the advisor skills table.
+func TestClaudeRenderer_InstallWorkflow_ReplacesAdvisorTablePlaceholder(t *testing.T) {
 	r := renderers.NewClaudeRenderer(claudeAgentDef())
 
-	// Set up installed skills containing an adviser-type skill.
-	advisers := []model.ContentItem{
+	// Set up installed skills containing an advisor-type skill.
+	advisors := []model.ContentItem{
 		{
 			Kind:        model.KindSkill,
-			Name:        "unit-test-adviser",
-			Path:        "skills/unit-test-adviser/",
+			Name:        "unit-test-advisor",
+			Path:        "skills/unit-test-advisor/",
 			Description: "Unit test patterns and structure",
 		},
 	}
-	r.SetInstalledSkills(advisers)
+	r.SetInstalledSkills(advisors)
 
 	// Create a temporary workflow directory with a SKILL.md containing the placeholder.
 	wfCacheDir := t.TempDir()
@@ -484,7 +484,7 @@ func TestClaudeRenderer_InstallWorkflow_ReplacesAdviserTablePlaceholder(t *testi
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatalf("mkdir skill dir: %v", err)
 	}
-	skillContent := "---\nname: sdd-explore\ndescription: Explore and investigate\n---\n<!-- ADVISER_TABLE_PLACEHOLDER -->\n"
+	skillContent := "---\nname: sdd-explore\ndescription: Explore and investigate\n---\n<!-- ADVISOR_TABLE_PLACEHOLDER -->\n"
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o644); err != nil {
 		t.Fatalf("write SKILL.md: %v", err)
 	}
@@ -525,11 +525,11 @@ components:
 	data := mustReadFile(t, destSkillMD)
 	content := string(data)
 
-	if strings.Contains(content, "<!-- ADVISER_TABLE_PLACEHOLDER -->") {
+	if strings.Contains(content, "<!-- ADVISOR_TABLE_PLACEHOLDER -->") {
 		t.Errorf("placeholder was not replaced; SKILL.md content:\n%s", content)
 	}
-	if !strings.Contains(content, "unit-test-adviser") {
-		t.Errorf("adviser table not injected; SKILL.md content:\n%s", content)
+	if !strings.Contains(content, "unit-test-advisor") {
+		t.Errorf("advisor table not injected; SKILL.md content:\n%s", content)
 	}
 }
 
@@ -842,12 +842,12 @@ func TestClaudeRenderer_InstallWorkflow_RegistryFallsBackWhenVariantMissing(t *t
 	}
 }
 
-// TestClaudeRenderer_InstallWorkflow_NoAdviserSkills verifies that when no adviser
+// TestClaudeRenderer_InstallWorkflow_NoAdvisorSkills verifies that when no advisor
 // skills are installed, the placeholder is removed (replaced with empty string).
-func TestClaudeRenderer_InstallWorkflow_NoAdviserSkills(t *testing.T) {
+func TestClaudeRenderer_InstallWorkflow_NoAdvisorSkills(t *testing.T) {
 	r := renderers.NewClaudeRenderer(claudeAgentDef())
 
-	// No adviser skills set — installedSkills is empty.
+	// No advisor skills set — installedSkills is empty.
 	r.SetInstalledSkills([]model.ContentItem{
 		{Kind: model.KindSkill, Name: "git-commit", Path: "skills/git-commit/", Description: "Commit changes"},
 	})
@@ -858,7 +858,7 @@ func TestClaudeRenderer_InstallWorkflow_NoAdviserSkills(t *testing.T) {
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatalf("mkdir skill dir: %v", err)
 	}
-	skillContent := "---\nname: sdd-explore\ndescription: Explore\n---\n<!-- ADVISER_TABLE_PLACEHOLDER -->\n"
+	skillContent := "---\nname: sdd-explore\ndescription: Explore\n---\n<!-- ADVISOR_TABLE_PLACEHOLDER -->\n"
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o644); err != nil {
 		t.Fatalf("write SKILL.md: %v", err)
 	}
@@ -885,8 +885,8 @@ func TestClaudeRenderer_InstallWorkflow_NoAdviserSkills(t *testing.T) {
 	content := string(data)
 
 	// Placeholder should be gone.
-	if strings.Contains(content, "<!-- ADVISER_TABLE_PLACEHOLDER -->") {
-		t.Errorf("placeholder should be removed when no adviser skills installed; content:\n%s", content)
+	if strings.Contains(content, "<!-- ADVISOR_TABLE_PLACEHOLDER -->") {
+		t.Errorf("placeholder should be removed when no advisor skills installed; content:\n%s", content)
 	}
 }
 
@@ -1342,7 +1342,7 @@ func TestClaudeRenderer_RenderSettings_MultipleHookFilesForClaudeAgentMerged(t *
 // --- T007: Claude-native renderer variant and subagent coverage ---
 
 // sddTestWorkflow returns the canonical SDD workflow manifest used by the T007
-// test suite: four phase subagents + orchestrator + adviser sentinel, matching
+// test suite: four phase subagents + orchestrator + advisor sentinel, matching
 // the real `devrune-starter-catalog/workflows/sdd/workflow.yaml`.
 func sddTestWorkflow() model.WorkflowManifest {
 	return model.WorkflowManifest{
@@ -1357,7 +1357,7 @@ func sddTestWorkflow() model.WorkflowManifest {
 				{Name: "sdd-implementer", Kind: "subagent", Skill: "sdd-implement", Model: "sonnet"},
 				{Name: "sdd-reviewer", Kind: "subagent", Skill: "sdd-review", Model: "opus"},
 				{Name: "sdd-orchestrator", Kind: "orchestrator"},
-				{Name: "sdd-adviser", Kind: "subagent", Skill: "*-adviser", Model: "opus"},
+				{Name: "sdd-advisor", Kind: "subagent", Skill: "*-advisor", Model: "opus"},
 			},
 		},
 	}
@@ -1496,13 +1496,13 @@ func TestClaudeRenderer_InstallWorkflow_PhaseSubagents_OmitToolsField(t *testing
 	}
 }
 
-// TestClaudeRenderer_InstallWorkflow_AdviserSubagents_DeclareReadOnlyTools
-// asserts that adviser subagent files have explicit `tools: [Read, Grep, Glob]`.
-func TestClaudeRenderer_InstallWorkflow_AdviserSubagents_DeclareReadOnlyTools(t *testing.T) {
+// TestClaudeRenderer_InstallWorkflow_AdvisorSubagents_DeclareReadOnlyTools
+// asserts that advisor subagent files have explicit `tools: [Read, Grep, Glob]`.
+func TestClaudeRenderer_InstallWorkflow_AdvisorSubagents_DeclareReadOnlyTools(t *testing.T) {
 	r := renderers.NewClaudeRenderer(claudeNativeAgentDef())
 	r.SetInstalledSkills([]model.ContentItem{
-		{Kind: model.KindSkill, Name: "architect-adviser", Path: "skills/architect-adviser/", Description: "Clean architecture"},
-		{Kind: model.KindSkill, Name: "unit-test-adviser", Path: "skills/unit-test-adviser/", Description: "Unit tests"},
+		{Kind: model.KindSkill, Name: "architect-advisor", Path: "skills/architect-advisor/", Description: "Clean architecture"},
+		{Kind: model.KindSkill, Name: "unit-test-advisor", Path: "skills/unit-test-advisor/", Description: "Unit tests"},
 	})
 
 	cache := writeClaudeSDDCache(t, "")
@@ -1513,12 +1513,12 @@ func TestClaudeRenderer_InstallWorkflow_AdviserSubagents_DeclareReadOnlyTools(t 
 	}
 
 	wantTools := map[string]bool{"Read": true, "Grep": true, "Glob": true}
-	for _, name := range []string{"architect-adviser", "unit-test-adviser"} {
+	for _, name := range []string{"architect-advisor", "unit-test-advisor"} {
 		t.Run(name, func(t *testing.T) {
 			fm := readAgentFrontmatter(t, workspace, name)
 			toolsVal, ok := fm["tools"]
 			if !ok {
-				t.Fatalf("%s.md: tools field is missing — advisers must declare read-only tools", name)
+				t.Fatalf("%s.md: tools field is missing — advisors must declare read-only tools", name)
 			}
 			toolsList, ok := toolsVal.([]any)
 			if !ok {
@@ -1547,7 +1547,7 @@ func TestClaudeRenderer_InstallWorkflow_AdviserSubagents_DeclareReadOnlyTools(t 
 func TestClaudeRenderer_InstallWorkflow_MCPServers(t *testing.T) {
 	r := renderers.NewClaudeRenderer(claudeNativeAgentDef())
 	r.SetInstalledSkills([]model.ContentItem{
-		{Kind: model.KindSkill, Name: "architect-adviser", Path: "skills/architect-adviser/", Description: "arch"},
+		{Kind: model.KindSkill, Name: "architect-advisor", Path: "skills/architect-advisor/", Description: "arch"},
 	})
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
@@ -1580,7 +1580,7 @@ func TestClaudeRenderer_InstallWorkflow_MCPServers(t *testing.T) {
 		{"sdd-planner", map[string]bool{"engram": true}},
 		{"sdd-implementer", map[string]bool{"engram": true}},
 		{"sdd-reviewer", map[string]bool{"engram": true}},
-		{"architect-adviser", map[string]bool{"engram": true}},
+		{"architect-advisor", map[string]bool{"engram": true}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.agent, func(t *testing.T) {
@@ -1767,7 +1767,7 @@ func TestClaudeRenderer_InstallWorkflow_ManagedPaths_PreserveUserAgents(t *testi
 func TestClaudeRenderer_InstallWorkflow_SubagentFileSizeUnder1KB(t *testing.T) {
 	r := renderers.NewClaudeRenderer(claudeNativeAgentDef())
 	r.SetInstalledSkills([]model.ContentItem{
-		{Kind: model.KindSkill, Name: "architect-adviser", Path: "skills/architect-adviser/", Description: "arch"},
+		{Kind: model.KindSkill, Name: "architect-advisor", Path: "skills/architect-advisor/", Description: "arch"},
 	})
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
@@ -1777,7 +1777,7 @@ func TestClaudeRenderer_InstallWorkflow_SubagentFileSizeUnder1KB(t *testing.T) {
 	}
 
 	const maxBytes = 1024
-	agents := []string{"sdd-explorer", "sdd-planner", "sdd-implementer", "sdd-reviewer", "architect-adviser"}
+	agents := []string{"sdd-explorer", "sdd-planner", "sdd-implementer", "sdd-reviewer", "architect-advisor"}
 	for _, name := range agents {
 		t.Run(name, func(t *testing.T) {
 			path := filepath.Join(workspace, "agents", name+".md")
@@ -1921,27 +1921,6 @@ func TestClaudeRenderer_RegenerateAdvisorFiles_NonAdvisorNamesIgnored(t *testing
 
 	assertAgentFileAbsent(t, workspaceRoot, "git-commit")
 	assertAgentFileAbsent(t, workspaceRoot, "sdd-plan")
-}
-
-// TestClaudeRenderer_RegenerateAdvisorFiles_LegacySuffix verifies that the legacy
-// "-adviser" suffix is accepted as a compat shim and produces an output file.
-func TestClaudeRenderer_RegenerateAdvisorFiles_LegacySuffix(t *testing.T) {
-	r := renderers.NewClaudeRenderer(advisorAgentDef())
-	workspaceRoot := t.TempDir()
-
-	installed := []model.ContentItem{
-		{Kind: model.KindSkill, Name: "security-adviser"},
-	}
-
-	result, err := r.RegenerateAdvisorFiles(workspaceRoot, installed, nil, nil)
-	if err != nil {
-		t.Fatalf("RegenerateAdvisorFiles: %v", err)
-	}
-
-	if len(result.Written) != 1 {
-		t.Errorf("Written = %v, want 1 entry for legacy '-adviser' suffix", result.Written)
-	}
-	assertAgentFileExists(t, workspaceRoot, "security-adviser")
 }
 
 // TestClaudeRenderer_RegenerateAdvisorFiles_IdempotencyByteIdentical verifies that
@@ -2107,7 +2086,7 @@ func TestClaudeRenderer_InstallWorkflow_NoSharedClaudeMdFiles(t *testing.T) {
 	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
 		t.Fatalf("mkdir _shared: %v", err)
 	}
-	for _, name := range []string{"launch-templates.md", "adviser-templates.md", "envelope-contract.md"} {
+	for _, name := range []string{"launch-templates.md", "advisor-templates.md", "envelope-contract.md"} {
 		if err := os.WriteFile(filepath.Join(sharedDir, name), []byte("# "+name+"\n"), 0o644); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}

--- a/internal/materialize/renderers/copilot.go
+++ b/internal/materialize/renderers/copilot.go
@@ -5,23 +5,16 @@ package renderers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/davidarce/devrune/internal/materialize/matypes"
 	"github.com/davidarce/devrune/internal/model"
 	"github.com/davidarce/devrune/internal/parse"
 )
-
-// copilotLegacyAdviserOnce gates the one-time deprecation log for "-adviser" suffixed
-// advisor names detected in RegenerateAdvisorFiles. Mirrors the Claude renderer's
-// behaviour so both renderers emit the warning at most once per process.
-var copilotLegacyAdviserOnce sync.Once
 
 // copilotToolAliases maps canonical tool names to GitHub Copilot tool aliases.
 var copilotToolAliases = map[string]string{
@@ -53,21 +46,13 @@ var copilotSubAgentTools = map[string][]string{
 	"sdd-implement": {"read", "search", "edit", "execute"},
 	"sdd-review":    {"read", "search", "execute"},
 	// Advisor roles — read and search only; they analyse the plan and their SKILL.md.
-	// Both -adviser (legacy) and -advisor (new) keys are kept for transition compat.
-	"architect-adviser":          {"read", "search"},
-	"architect-advisor":          {"read", "search"},
-	"api-first-adviser":          {"read", "search"},
-	"api-first-advisor":          {"read", "search"},
-	"unit-test-adviser":          {"read", "search"},
-	"unit-test-advisor":          {"read", "search"},
-	"integration-test-adviser":   {"read", "search"},
-	"integration-test-advisor":   {"read", "search"},
-	"component-adviser":          {"read", "search"},
-	"component-advisor":          {"read", "search"},
-	"frontend-test-adviser":      {"read", "search"},
-	"frontend-test-advisor":      {"read", "search"},
-	"web-accessibility-adviser":  {"read", "search"},
-	"web-accessibility-advisor":  {"read", "search"},
+	"architect-advisor":         {"read", "search"},
+	"api-first-advisor":         {"read", "search"},
+	"unit-test-advisor":         {"read", "search"},
+	"integration-test-advisor":  {"read", "search"},
+	"component-advisor":         {"read", "search"},
+	"frontend-test-advisor":     {"read", "search"},
+	"web-accessibility-advisor": {"read", "search"},
 }
 
 // copilotBodyReplacements maps Claude Code MCP shorthand tool calls to Copilot
@@ -538,7 +523,7 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	}
 
 	// T018: Generate native sub-agent .agent.md files for each subagent role.
-	// Skip sentinel roles (e.g. sdd-adviser with skill "*-adviser") — these exist
+	// Skip sentinel roles (e.g. sdd-advisor with skill "*-advisor") — these exist
 	// only for model placeholder generation, not for .agent.md synthesis.
 	for _, role := range wf.Components.Roles {
 		if role.Kind != "subagent" || role.Skill == "" || strings.Contains(role.Skill, "*") {
@@ -558,7 +543,7 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	// than embedding the full content (avoiding duplication).
 	if advisorEntries, err := os.ReadDir(skillsBase); err == nil {
 		for _, entry := range advisorEntries {
-			if !entry.IsDir() || (!strings.HasSuffix(entry.Name(), "-advisor") && !strings.HasSuffix(entry.Name(), "-adviser")) {
+			if !entry.IsDir() || !strings.HasSuffix(entry.Name(), "-advisor") {
 				continue
 			}
 			advisorName := entry.Name()
@@ -818,15 +803,13 @@ func (r *CopilotRenderer) generateAdvisorAgentFile(agentsBase, advisorName strin
 		"user-invocable":           false,
 		"disable-model-invocation": false,
 	}
-	// Add model: check for an exact override first, then fall back to the SDD advisor/adviser
-	// sentinel. sdd-adviser (skill: "*-adviser") is the sentinel that represents all advisors
-	// in the SDD workflow, so its model override applies to any advisor wrapper without its own override.
+	// Add model: check for an exact override first, then fall back to the SDD advisor
+	// sentinel. sdd-advisor (skill: "*-advisor") is the sentinel that represents all
+	// advisors in the SDD workflow, so its model override applies to any advisor wrapper
+	// without its own override.
 	advisorModel := modelOverrides[advisorName]
 	if advisorModel == "" || advisorModel == model.ModelInheritOption {
-		advisorModel = modelOverrides["sdd-advisor"] // primary sentinel
-	}
-	if advisorModel == "" || advisorModel == model.ModelInheritOption {
-		advisorModel = modelOverrides["sdd-adviser"] // legacy compat shim
+		advisorModel = modelOverrides["sdd-advisor"]
 	}
 	if advisorModel != "" && advisorModel != model.ModelInheritOption {
 		fm["model"] = advisorModel
@@ -855,11 +838,7 @@ func (r *CopilotRenderer) generateAdvisorAgentFile(agentsBase, advisorName strin
 //
 // Detection rule (identical across all AdvisorRenderer implementations):
 //
-//	hasAdvisorSuffix := strings.HasSuffix(strings.ToLower(item.Name), "-advisor")
-//	hasLegacySuffix  := strings.HasSuffix(strings.ToLower(item.Name), "-adviser") // compat shim
-//	isAdvisor        := hasAdvisorSuffix || hasLegacySuffix || item.Custom
-//
-// The legacy "-adviser" suffix triggers a one-time deprecation log via sync.Once.
+//	isAdvisor := strings.HasSuffix(strings.ToLower(item.Name), "-advisor") || item.Custom
 func (r *CopilotRenderer) RegenerateAdvisorFiles(
 	workspaceRoot string,
 	installed []model.ContentItem,
@@ -878,20 +857,9 @@ func (r *CopilotRenderer) RegenerateAdvisorFiles(
 
 	// Process installed advisors.
 	for _, item := range installed {
-		name := strings.ToLower(item.Name)
-		hasAdvisorSuffix := strings.HasSuffix(name, "-advisor")
-		hasLegacySuffix := strings.HasSuffix(name, "-adviser")
-		isAdvisor := hasAdvisorSuffix || hasLegacySuffix || item.Custom
-
+		isAdvisor := strings.HasSuffix(strings.ToLower(item.Name), "-advisor") || item.Custom
 		if !isAdvisor {
 			continue
-		}
-
-		// Emit one-time deprecation log for legacy "-adviser" suffix.
-		if hasLegacySuffix && !item.Custom {
-			copilotLegacyAdviserOnce.Do(func() {
-				log.Printf("copilot: deprecated advisor suffix \"-adviser\" detected for %q; rename to \"-advisor\" (support will be removed in the next minor release)", item.Name)
-			})
 		}
 
 		written, err := r.generateAdvisorAgentFile(agentsBase, item.Name, modelOverrides, workspaceRoot)

--- a/internal/materialize/renderers/copilot_test.go
+++ b/internal/materialize/renderers/copilot_test.go
@@ -1818,7 +1818,7 @@ func TestCopilotRenderer_RegenerateAdvisorFiles_RemoveNonExistent(t *testing.T) 
 }
 
 // TestCopilotRenderer_RegenerateAdvisorFiles_NonAdvisorNamesIgnored verifies that
-// items without "-advisor" or "-adviser" suffix and Custom=false are silently ignored.
+// items without "-advisor" or "-advisor" suffix and Custom=false are silently ignored.
 func TestCopilotRenderer_RegenerateAdvisorFiles_NonAdvisorNamesIgnored(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	r := renderers.NewCopilotRenderer(copilotAdvisorDef(workspaceRoot))
@@ -1843,32 +1843,6 @@ func TestCopilotRenderer_RegenerateAdvisorFiles_NonAdvisorNamesIgnored(t *testin
 		if _, err := os.Stat(agentPath); err == nil {
 			t.Errorf("%s.agent.md must NOT be created for non-advisor skill", name)
 		}
-	}
-}
-
-// TestCopilotRenderer_RegenerateAdvisorFiles_LegacySuffixCompat verifies that a
-// ContentItem with legacy "-adviser" suffix still produces an .agent.md file.
-func TestCopilotRenderer_RegenerateAdvisorFiles_LegacySuffixCompat(t *testing.T) {
-	workspaceRoot := t.TempDir()
-	r := renderers.NewCopilotRenderer(copilotAdvisorDef(workspaceRoot))
-
-	installed := []model.ContentItem{
-		{Kind: model.KindSkill, Name: "security-adviser", Path: "skills/security-adviser/", Description: "Security advice"},
-	}
-
-	result, err := r.RegenerateAdvisorFiles(workspaceRoot, installed, nil, nil)
-	if err != nil {
-		t.Fatalf("RegenerateAdvisorFiles: %v", err)
-	}
-
-	if len(result.Written) != 1 {
-		t.Errorf("Written = %d paths, want 1; paths: %v", len(result.Written), result.Written)
-	}
-
-	// File must use the original name (security-adviser) with .agent.md extension.
-	agentPath := filepath.Join(workspaceRoot, "agents", "security-adviser.agent.md")
-	if _, err := os.Stat(agentPath); err != nil {
-		t.Errorf("security-adviser.agent.md must exist (legacy suffix compat): %v", err)
 	}
 }
 

--- a/internal/materialize/renderers/helpers.go
+++ b/internal/materialize/renderers/helpers.go
@@ -777,7 +777,6 @@ func buildWorkflowPlaceholderReplacements(
 		"IMPLEMENTER": "{SDD_MODEL_IMPLEMENT}",
 		"REVIEWER":    "{SDD_MODEL_REVIEW}",
 		"ADVISOR":     "{SDD_MODEL_ADVISOR}",
-		"ADVISER":     "{SDD_MODEL_ADVISER}",
 	}
 
 	for _, role := range wf.Components.Roles {
@@ -1124,19 +1123,19 @@ func skillDescriptionForRole(skill string) string {
 		return "SDD Implement sub-agent"
 	case "sdd-review":
 		return "SDD Review sub-agent"
-	case "architect-advisor", "architect-adviser":
+	case "architect-advisor":
 		return "Clean architecture advisor: hexagonal, DDD, ports and adapters"
-	case "api-first-advisor", "api-first-adviser":
+	case "api-first-advisor":
 		return "API-first design advisor: OpenAPI, REST conventions, error models"
-	case "unit-test-advisor", "unit-test-adviser":
+	case "unit-test-advisor":
 		return "Unit test advisor: test structure, mocking, Given-When-Then"
-	case "integration-test-advisor", "integration-test-adviser":
+	case "integration-test-advisor":
 		return "Integration test advisor: adapter testing, external service mocking"
-	case "component-advisor", "component-adviser":
+	case "component-advisor":
 		return "React component advisor: composition, hooks, state management"
-	case "frontend-test-advisor", "frontend-test-adviser":
+	case "frontend-test-advisor":
 		return "Frontend test advisor: React Testing Library, Vitest, Cypress"
-	case "web-accessibility-advisor", "web-accessibility-adviser":
+	case "web-accessibility-advisor":
 		return "Web accessibility advisor: WCAG 2.1 AA, ARIA, keyboard navigation"
 	default:
 		return skill + " sub-agent"

--- a/internal/recommend/engine_test.go
+++ b/internal/recommend/engine_test.go
@@ -66,9 +66,9 @@ func sampleProfile() detect.ProjectProfile {
 // sampleCatalog returns a minimal catalog for testing.
 func sampleCatalog() []recommend.CatalogItem {
 	return []recommend.CatalogItem{
-		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Description: "Clean architecture patterns"},
+		{Name: "architect-advisor", Kind: "skill", Source: "github:owner/catalog", Description: "Clean architecture patterns"},
 		{Name: "react", Kind: "rule", Source: "github:owner/catalog", Description: "React coding standards"},
-		{Name: "unit-test-adviser", Kind: "skill", Source: "github:owner/catalog", Description: "Unit test patterns"},
+		{Name: "unit-test-advisor", Kind: "skill", Source: "github:owner/catalog", Description: "Unit test patterns"},
 	}
 }
 
@@ -136,8 +136,8 @@ func TestRecommend_MockAgent_ReturnsFilteredRecommendations(t *testing.T) {
 	for _, r := range result.Recommendations {
 		names[r.Name] = r.Confidence
 	}
-	if c, ok := names["architect-adviser"]; !ok || c != 0.92 {
-		t.Errorf("expected architect-adviser with confidence=0.92, got: %v", names)
+	if c, ok := names["architect-advisor"]; !ok || c != 0.92 {
+		t.Errorf("expected architect-advisor with confidence=0.92, got: %v", names)
 	}
 	if c, ok := names["react"]; !ok || c != 0.85 {
 		t.Errorf("expected react with confidence=0.85, got: %v", names)
@@ -186,7 +186,7 @@ func TestWriteRecommendedYAML_WritesValidYAML(t *testing.T) {
 	result := &recommend.RecommendResult{
 		Recommendations: []recommend.Recommendation{
 			{
-				Name:       "architect-adviser",
+				Name:       "architect-advisor",
 				Kind:       "skill",
 				Source:     "github:owner/catalog",
 				Confidence: 0.92,
@@ -217,8 +217,8 @@ func TestWriteRecommendedYAML_WritesValidYAML(t *testing.T) {
 	if !strings.Contains(content, "devrune/recommend/v1") {
 		t.Errorf("expected schemaVersion in output; got:\n%s", content)
 	}
-	if !strings.Contains(content, "architect-adviser") {
-		t.Errorf("expected architect-adviser in output; got:\n%s", content)
+	if !strings.Contains(content, "architect-advisor") {
+		t.Errorf("expected architect-advisor in output; got:\n%s", content)
 	}
 	if !strings.Contains(content, "generatedAt") {
 		t.Errorf("expected generatedAt in output; got:\n%s", content)

--- a/internal/recommend/testdata/mock-agent.sh
+++ b/internal/recommend/testdata/mock-agent.sh
@@ -2,5 +2,5 @@
 # Mock AI agent script for testing recommend.Engine.
 # Outputs a Claude-style JSON envelope with structured_output.
 cat <<'EOF'
-{"type":"result","subtype":"success","result":"","session_id":"test-session","structured_output":{"recommendations":[{"name":"architect-adviser","kind":"skill","source":"github:owner/catalog","confidence":0.92,"reason":"Project uses hexagonal architecture patterns"},{"name":"react","kind":"rule","source":"github:owner/catalog","confidence":0.85,"reason":"React detected in package.json"},{"name":"low-confidence-item","kind":"skill","source":"github:owner/catalog","confidence":0.45,"reason":"Weakly related item below default threshold"}]}}
+{"type":"result","subtype":"success","result":"","session_id":"test-session","structured_output":{"recommendations":[{"name":"architect-advisor","kind":"skill","source":"github:owner/catalog","confidence":0.92,"reason":"Project uses hexagonal architecture patterns"},{"name":"react","kind":"rule","source":"github:owner/catalog","confidence":0.85,"reason":"React detected in package.json"},{"name":"low-confidence-item","kind":"skill","source":"github:owner/catalog","confidence":0.45,"reason":"Weakly related item below default threshold"}]}}
 EOF

--- a/internal/resolve/enumerator_test.go
+++ b/internal/resolve/enumerator_test.go
@@ -404,8 +404,8 @@ description: React and TypeScript coding standards
 scope: tech
 technology: any
 applies-to:
-  - component-adviser
-  - frontend-test-adviser
+  - component-advisor
+  - frontend-test-advisor
 ---
 # React rules body
 `)
@@ -424,7 +424,7 @@ scope: architecture
 	writeFile(t, dir, "rules/api/legacy-rule.md", `---
 description: Legacy rule with underscore key
 scope: api
-applies_to: adviser-a, adviser-b
+applies_to: advisor-a, advisor-b
 ---
 # Legacy rule body
 `)
@@ -459,8 +459,8 @@ applies_to: adviser-a, adviser-b
 	if reactRule.RuleMeta.Technology != "any" {
 		t.Errorf("Technology = %q, want %q", reactRule.RuleMeta.Technology, "any")
 	}
-	if reactRule.RuleMeta.AppliesTo != "component-adviser, frontend-test-adviser" {
-		t.Errorf("AppliesTo = %q, want %q", reactRule.RuleMeta.AppliesTo, "component-adviser, frontend-test-adviser")
+	if reactRule.RuleMeta.AppliesTo != "component-advisor, frontend-test-advisor" {
+		t.Errorf("AppliesTo = %q, want %q", reactRule.RuleMeta.AppliesTo, "component-advisor, frontend-test-advisor")
 	}
 	if reactRule.RuleMeta.DisplayName != "react" {
 		t.Errorf("DisplayName = %q, want %q", reactRule.RuleMeta.DisplayName, "react")
@@ -508,7 +508,7 @@ applies_to: adviser-a, adviser-b
 	if legacyRule.RuleMeta == nil {
 		t.Fatal("api/legacy-rule RuleMeta should not be nil")
 	}
-	if legacyRule.RuleMeta.AppliesTo != "adviser-a, adviser-b" {
-		t.Errorf("legacy AppliesTo = %q, want %q", legacyRule.RuleMeta.AppliesTo, "adviser-a, adviser-b")
+	if legacyRule.RuleMeta.AppliesTo != "advisor-a, advisor-b" {
+		t.Errorf("legacy AppliesTo = %q, want %q", legacyRule.RuleMeta.AppliesTo, "advisor-a, advisor-b")
 	}
 }

--- a/internal/tui/steps/recommend_test.go
+++ b/internal/tui/steps/recommend_test.go
@@ -28,8 +28,8 @@ func TestMerge_AddsRecommendedItems(t *testing.T) {
 	prev := makePrevSelection([]string{"git-commit"}, nil)
 
 	recs := []recommend.Recommendation{
-		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
-		{Name: "unit-test-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.85},
+		{Name: "architect-advisor", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
+		{Name: "unit-test-advisor", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.85},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0.7)
@@ -43,7 +43,7 @@ func TestMerge_AddsRecommendedItems(t *testing.T) {
 	for _, s := range skills {
 		has[s] = true
 	}
-	for _, expected := range []string{"git-commit", "architect-adviser", "unit-test-adviser"} {
+	for _, expected := range []string{"git-commit", "architect-advisor", "unit-test-advisor"} {
 		if !has[expected] {
 			t.Errorf("expected %q in merged skills", expected)
 		}
@@ -55,7 +55,7 @@ func TestMerge_BelowThresholdNotAdded(t *testing.T) {
 	prev := makePrevSelection(nil, nil)
 
 	recs := []recommend.Recommendation{
-		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.45},
+		{Name: "architect-advisor", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.45},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0.7)
@@ -67,10 +67,10 @@ func TestMerge_BelowThresholdNotAdded(t *testing.T) {
 
 // TestMerge_NoDuplicates verifies already-selected items are not duplicated.
 func TestMerge_NoDuplicates(t *testing.T) {
-	prev := makePrevSelection([]string{"architect-adviser"}, nil)
+	prev := makePrevSelection([]string{"architect-advisor"}, nil)
 
 	recs := []recommend.Recommendation{
-		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
+		{Name: "architect-advisor", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0.7)
@@ -85,7 +85,7 @@ func TestMerge_PreservesOriginalSelection(t *testing.T) {
 	prev := makePrevSelection([]string{"git-commit"}, []string{"clean-architecture"})
 
 	recs := []recommend.Recommendation{
-		{Name: "architect-adviser", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
+		{Name: "architect-advisor", Kind: "skill", Source: "github:owner/catalog", Confidence: 0.92},
 	}
 
 	merged := steps.MergeRecommendationsIntoSelection(prev, recs, 0.7)


### PR DESCRIPTION
## Summary

PR #49 introduced one-release compat shims for the `adviser → advisor` rename, but the advisor feature is itself new — no installations exist in the wild that still use the legacy naming. The shims are dead weight from day one and add cognitive load to every future change in this area.

This PR removes them.

## What's removed

### `internal/materialize/renderers/claude.go`
- `deprecateAdviserSuffixOnce` `sync.Once` + the deprecation log emitted from `RegenerateAdvisorFiles`
- 7 `*-adviser` keys in `claudeSubAgentTools` and `claudeSubAgentMCPServers` (`*-advisor` keys remain)
- The `-adviser` branch in `synthesizeAdvisorWrappers` and `RegenerateAdvisorFiles` detection
- The `<!-- ADVISER_TABLE_PLACEHOLDER -->` alias in `postProcessWorkflow`
- The legacy `adviser-templates.md` cleanup line (superseded by `advisor-templates.md`)
- The `adviser` substring check in `buildAdvisorTable`
- Unused `log`/`sync` imports

### `internal/materialize/renderers/copilot.go`
- `copilotLegacyAdviserOnce` + its deprecation log
- 7 `*-adviser` keys in `copilotSubAgentTools`
- `modelOverrides["sdd-adviser"]` fallback in `generateAdvisorAgentFile`
- The `-adviser` branch in `InstallWorkflow` and `RegenerateAdvisorFiles`
- Unused `log`/`sync` imports

### `internal/materialize/renderers/helpers.go`
- `ADVISER → {SDD_MODEL_ADVISER}` entry in `sddLegacyMap`
- `*-adviser` case keys in `skillDescriptionForRole`

### `internal/materialize/advisor_renderer.go`
- Detection-rule and deprecation note referencing the legacy suffix in the `AdvisorRenderer` port doc comment

### `internal/cli/sdd_advisors.go`
- The `sdd-advisers` command alias and its mention in `Long`

### Tests
- Deletes `TestClaudeRenderer_RegenerateAdvisorFiles_LegacySuffix` and `TestCopilotRenderer_RegenerateAdvisorFiles_LegacySuffixCompat` — they asserted the now-removed compat behaviour.
- Renames `*-adviser` test fixtures → `*-advisor` across claude/copilot/materializer/catalog test files, `enumerator_test.go`, `recommend/engine_test.go`, `recommend_test.go`, `e2e_test.go`, and `recommend/testdata/mock-agent.sh`.
- Renames `ADVISER_TABLE_PLACEHOLDER` fixture → `ADVISOR_TABLE_PLACEHOLDER`.
- Updates comments and test function names to drop the British spelling on test-asset code paths.

## Kept intentionally

- **`TestAdvisorDef_Validate/shouldRejectWhenNameUsesLegacyAdviserSuffix`** — verifies that names ending in `-adviser` are now REJECTED (the outcome we want), not that they are accepted.
- **`recommend.FilterAdvisersByProfile` and friends** — Go API names use British "Advisers" plural. Not a compat shim, separate concern from this cleanup.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green except the pre-existing `TestReservedAdvisorNamesMatchesDisk` failure (unrelated; depends on `.claude/skills/*-advisor/SKILL.md` being present in the working copy, which it is on CI).
- [ ] CI green.
- [ ] Optional: clear the DevRune cache and re-run `devrune install` to confirm a fresh install still produces only `*-advisor` artefacts (this PR doesn't change runtime behaviour for valid inputs — it only stops accepting legacy ones).

## Diff stats

`14 files changed, 150 insertions(+), 290 deletions(-)` — net **−140** lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)