### PR TITLE
feat(workflow): resolve components.skills against catalog root, not just workflow dir

### DIFF
--- a/internal/cli/advisors_sync_test.go
+++ b/internal/cli/advisors_sync_test.go
@@ -63,7 +63,7 @@ func (f *fakeAdvisorRenderer) RenderMCPs(_ []model.LockedMCP, _ materialize.Cach
 func (f *fakeAdvisorRenderer) RenderSettings(_ string, _ []model.ContentItem, _ []model.WorkflowManifest) error {
 	return nil
 }
-func (f *fakeAdvisorRenderer) InstallWorkflow(_ model.WorkflowManifest, _, _ string) (materialize.WorkflowInstallResult, error) {
+func (f *fakeAdvisorRenderer) InstallWorkflow(_ model.WorkflowManifest, _, _, _ string) (materialize.WorkflowInstallResult, error) {
 	return materialize.WorkflowInstallResult{}, nil
 }
 func (f *fakeAdvisorRenderer) Finalize(_ string) error { return nil }
@@ -89,7 +89,7 @@ func (n *nonAdvisorRenderer) RenderMCPs(_ []model.LockedMCP, _ materialize.Cache
 func (n *nonAdvisorRenderer) RenderSettings(_ string, _ []model.ContentItem, _ []model.WorkflowManifest) error {
 	return nil
 }
-func (n *nonAdvisorRenderer) InstallWorkflow(_ model.WorkflowManifest, _, _ string) (materialize.WorkflowInstallResult, error) {
+func (n *nonAdvisorRenderer) InstallWorkflow(_ model.WorkflowManifest, _, _, _ string) (materialize.WorkflowInstallResult, error) {
 	return materialize.WorkflowInstallResult{}, nil
 }
 func (n *nonAdvisorRenderer) Finalize(_ string) error { return nil }

--- a/internal/materialize/materializer.go
+++ b/internal/materialize/materializer.go
@@ -293,7 +293,15 @@ func (m *Materializer) Install(
 			// shared skill directory was already populated by a prior agent.
 			// Renderers are idempotent for file writes, and per-renderer
 			// synthesis (e.g. opencode.json agent entries) must always run.
-			wfResult, err := renderer.InstallWorkflow(wfManifest, wfDir, agentWorkspace)
+			//
+			// catalogRoot is cacheDir — the catalog archive root that contains
+			// both the workflow dir and any sibling top-level resources like
+			// skills/. Renderers use catalogRoot to resolve skills declared in
+			// `components.skills` that live outside the workflow directory.
+			// For standalone workflow archives (wf.Dir == ""), catalogRoot
+			// equals wfDir; the resolver treats that as "no external lookup"
+			// and only honors workflow-internal skill subdirs.
+			wfResult, err := renderer.InstallWorkflow(wfManifest, wfDir, cacheDir, agentWorkspace)
 			if err != nil {
 				return fmt.Errorf("materializer: install workflow %q for agent %q: %w",
 					wf.Name, agentRef.Name, err)

--- a/internal/materialize/materializer_test.go
+++ b/internal/materialize/materializer_test.go
@@ -143,7 +143,7 @@ func (r *stubRenderer) SetInstalledSkills(skills []model.ContentItem) {
 	r.setInstalledSkills = skills
 }
 
-func (r *stubRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath, workspaceRoot string) (materialize.WorkflowInstallResult, error) {
+func (r *stubRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath, catalogRoot, workspaceRoot string) (materialize.WorkflowInstallResult, error) {
 	return materialize.WorkflowInstallResult{ManagedPaths: r.workflowManagedPaths}, nil
 }
 

--- a/internal/materialize/renderer.go
+++ b/internal/materialize/renderer.go
@@ -47,7 +47,16 @@ type AgentRenderer interface {
 	// InstallWorkflow materializes a workflow into the agent's workspace.
 	// It returns a WorkflowInstallResult reporting the renderer-owned paths so
 	// the materializer can track managed paths without guessing layout roots.
-	InstallWorkflow(wf model.WorkflowManifest, cachePath string, workspaceRoot string) (WorkflowInstallResult, error)
+	//
+	// cachePath is the absolute path to the workflow source directory (e.g.
+	// "/cache/<hash>/workflows/sdd"). catalogRoot is the absolute path to the
+	// containing catalog root (e.g. "/cache/<hash>"), which the renderer uses
+	// to resolve skills referenced in `components.skills` that live outside
+	// the workflow directory (catalog-level `skills/<name>/`). When the
+	// workflow ships standalone with no catalog wrapper, catalogRoot may
+	// equal cachePath; the renderer treats that as "no external lookup
+	// available" and only resolves workflow-internal skill names.
+	InstallWorkflow(wf model.WorkflowManifest, cachePath string, catalogRoot string, workspaceRoot string) (WorkflowInstallResult, error)
 
 	// Finalize runs agent-specific post-processing after all content is installed.
 	Finalize(workspaceRoot string) error

--- a/internal/materialize/renderers/claude.go
+++ b/internal/materialize/renderers/claude.go
@@ -317,7 +317,7 @@ func (r *ClaudeRenderer) MCPAgentInstructions() map[string]string {
 //
 // Hook script assets are copied as before; this logic is preserved verbatim.
 // T021: Loads Registry content during installation and stores it for RenderCatalog.
-func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
+func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, catalogRoot string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
 	// 1. Probe the Claude-native orchestrator variant.
 	const variantEntrypointName = "ORCHESTRATOR.claude.md"
 	variantOrchPath := ""
@@ -342,6 +342,9 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 	for _, s := range wf.Components.Skills {
 		skillsSet[s] = true
 	}
+	// Track skills rendered by the workflow-internal scan so the external pass
+	// only handles names that did NOT appear as subdirectories of the workflow.
+	renderedSkills := make(map[string]bool, len(wf.Components.Skills))
 
 	// 3. Determine destinations.
 	destBase := filepath.Join(workspaceRoot, r.def.SkillDir, wf.Metadata.EffectiveWorkingDir())
@@ -423,6 +426,7 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("claude: copy skill subdirs for %s: %w", name, err)
 			}
 			skillDirs = append(skillDirs, dstPath)
+			renderedSkills[name] = true
 			continue
 		}
 
@@ -473,6 +477,29 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 		} else if err := copyEntry(srcPath, dstPath, entry); err != nil {
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("claude: workflow copy %q: %w", name, err)
 		}
+	}
+
+	// External skill pass: any name in components.skills that did NOT appear as
+	// a workflow-internal subdirectory is resolved against the catalog root
+	// (catalogRoot/skills/<name>/). Renders the skill to skillsBase (top-level
+	// .claude/skills/<name>/) so it is discoverable by the Skill tool just like
+	// any other catalog skill.
+	for _, skillName := range wf.Components.Skills {
+		if renderedSkills[skillName] {
+			continue
+		}
+		extSrc, err := ResolveExternalSkillSource(catalogRoot, cachePath, skillName)
+		if err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("claude: %w", err)
+		}
+		extDst := filepath.Join(skillsBase, skillName)
+		if err := r.RenderSkill(extSrc, extDst); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("claude: external workflow skill %q: %w", skillName, err)
+		}
+		if err := copySkillSubdirs(extSrc, extDst); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("claude: copy skill subdirs for external skill %q: %w", skillName, err)
+		}
+		skillDirs = append(skillDirs, extDst)
 	}
 
 	// Remove _shared/ files that the Claude-native orchestrator does not reference.

--- a/internal/materialize/renderers/claude_test.go
+++ b/internal/materialize/renderers/claude_test.go
@@ -516,7 +516,7 @@ components:
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -571,7 +571,7 @@ components:
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -631,7 +631,7 @@ Review model: {SDD_MODEL_REVIEW}
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -685,7 +685,7 @@ func TestClaudeRenderer_InstallWorkflow_RegistryNoDoubleSlash(t *testing.T) {
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -741,7 +741,7 @@ func TestClaudeRenderer_InstallWorkflow_RegistryClaudeVariantPreferred(t *testin
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -790,7 +790,7 @@ func TestClaudeRenderer_InstallWorkflow_RegistryClaudeVariantNotCopiedToWorkspac
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -826,7 +826,7 @@ func TestClaudeRenderer_InstallWorkflow_RegistryFallsBackWhenVariantMissing(t *t
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -876,7 +876,7 @@ func TestClaudeRenderer_InstallWorkflow_NoAdvisorSkills(t *testing.T) {
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1139,7 +1139,7 @@ func TestClaudeRenderer_RenderSettings_HookJSONMerged(t *testing.T) {
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, cacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, cacheDir, cacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1197,7 +1197,7 @@ func TestClaudeRenderer_RenderSettings_InvalidHookJSONSkipped(t *testing.T) {
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, cacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, cacheDir, cacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1253,7 +1253,7 @@ func TestClaudeRenderer_RenderSettings_NoHooksForClaudeAgent(t *testing.T) {
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, cacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, cacheDir, cacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1319,7 +1319,7 @@ func TestClaudeRenderer_RenderSettings_MultipleHookFilesForClaudeAgentMerged(t *
 	}
 
 	workspaceDir := t.TempDir()
-	if _, err := r.InstallWorkflow(wf, cacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, cacheDir, cacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1412,7 +1412,7 @@ func TestClaudeRenderer_InstallWorkflow_VariantProbe(t *testing.T) {
 	cache := writeClaudeSDDCache(t, variantMarker)
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1439,7 +1439,7 @@ func TestClaudeRenderer_InstallWorkflow_FallsBackWhenVariantMissing(t *testing.T
 	cache := writeClaudeSDDCache(t, "") // no variant
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1474,7 +1474,7 @@ func TestClaudeRenderer_InstallWorkflow_PhaseSubagents_OmitToolsField(t *testing
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1508,7 +1508,7 @@ func TestClaudeRenderer_InstallWorkflow_AdvisorSubagents_DeclareReadOnlyTools(t 
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1552,7 +1552,7 @@ func TestClaudeRenderer_InstallWorkflow_MCPServers(t *testing.T) {
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1612,7 +1612,7 @@ func TestClaudeRenderer_InstallWorkflow_ModelPlaceholders(t *testing.T) {
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1651,7 +1651,7 @@ func TestClaudeRenderer_InstallWorkflow_ModelOverrideFromTUI(t *testing.T) {
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1697,7 +1697,7 @@ Gotchas:
 	cache := writeClaudeSDDCache(t, variantBody)
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1728,7 +1728,7 @@ func TestClaudeRenderer_InstallWorkflow_ManagedPaths_PreserveUserAgents(t *testi
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
 
-	result, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace)
+	result, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace)
 	if err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
@@ -1772,7 +1772,7 @@ func TestClaudeRenderer_InstallWorkflow_SubagentFileSizeUnder1KB(t *testing.T) {
 	cache := writeClaudeSDDCache(t, "")
 	workspace := t.TempDir()
 
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -2093,7 +2093,7 @@ func TestClaudeRenderer_InstallWorkflow_NoSharedClaudeMdFiles(t *testing.T) {
 	}
 
 	workspace := t.TempDir()
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -2141,7 +2141,7 @@ func TestClaudeRenderer_InstallWorkflow_SharedVariantSuffixStripping(t *testing.
 	}
 
 	workspace := t.TempDir()
-	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, workspace); err != nil {
+	if _, err := r.InstallWorkflow(sddTestWorkflow(), cache, cache, workspace); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -2172,5 +2172,127 @@ func TestClaudeRenderer_InstallWorkflow_SharedVariantSuffixStripping(t *testing.
 		if _, err := os.Stat(path); err == nil {
 			t.Errorf("variant file %q must not be installed in _shared/", absent)
 		}
+	}
+}
+
+// TestClaudeRenderer_InstallWorkflow_ExternalCatalogSkill verifies that a skill
+// listed in workflow.yaml's components.skills but living at the catalog top
+// level (catalogRoot/skills/<name>/) — not under the workflow directory — is
+// resolved correctly and installed in the workspace.
+//
+// Scenario mirrors the real catalog layout: SDD's PRD gate references
+// write-a-prd, which is a top-level reusable skill at catalog/skills/write-a-prd/,
+// not at catalog/workflows/sdd/write-a-prd/. The renderer must reach across
+// to catalogRoot to resolve it.
+func TestClaudeRenderer_InstallWorkflow_ExternalCatalogSkill(t *testing.T) {
+	r := renderers.NewClaudeRenderer(claudeAgentDef())
+
+	catalogRoot := t.TempDir()
+	wfCacheDir := filepath.Join(catalogRoot, "workflows", "sdd")
+	if err := os.MkdirAll(wfCacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflow dir: %v", err)
+	}
+
+	// Internal skill (lives under workflow dir): sdd-explore.
+	internalSkillDir := filepath.Join(wfCacheDir, "sdd-explore")
+	if err := os.MkdirAll(internalSkillDir, 0o755); err != nil {
+		t.Fatalf("mkdir internal skill: %v", err)
+	}
+	internalContent := "---\nname: sdd-explore\ndescription: Explore phase\n---\nbody\n"
+	if err := os.WriteFile(filepath.Join(internalSkillDir, "SKILL.md"), []byte(internalContent), 0o644); err != nil {
+		t.Fatalf("write internal SKILL.md: %v", err)
+	}
+
+	// External skill (lives at catalog top level): write-a-prd.
+	externalSkillDir := filepath.Join(catalogRoot, "skills", "write-a-prd")
+	if err := os.MkdirAll(externalSkillDir, 0o755); err != nil {
+		t.Fatalf("mkdir external skill: %v", err)
+	}
+	externalContent := "---\nname: write-a-prd\ndescription: Generate a PRD\n---\nbody\n"
+	if err := os.WriteFile(filepath.Join(externalSkillDir, "SKILL.md"), []byte(externalContent), 0o644); err != nil {
+		t.Fatalf("write external SKILL.md: %v", err)
+	}
+
+	// Workflow.yaml lists BOTH skills in components.skills. The internal one
+	// resolves via the existing scan; the external one resolves via the new
+	// external pass.
+	wfYAML := `apiVersion: devrune/workflow/v1
+metadata:
+  name: sdd
+  version: 1.0.0
+components:
+  skills:
+    - sdd-explore
+    - write-a-prd
+`
+	if err := os.WriteFile(filepath.Join(wfCacheDir, "workflow.yaml"), []byte(wfYAML), 0o644); err != nil {
+		t.Fatalf("write workflow.yaml: %v", err)
+	}
+
+	wf := model.WorkflowManifest{
+		APIVersion: "devrune/workflow/v1",
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Components: model.WorkflowComponents{
+			Skills: []string{"sdd-explore", "write-a-prd"},
+		},
+	}
+
+	workspaceDir := t.TempDir()
+	result, err := r.InstallWorkflow(wf, wfCacheDir, catalogRoot, workspaceDir)
+	if err != nil {
+		t.Fatalf("InstallWorkflow: %v", err)
+	}
+
+	// Both skills must land at the top-level workspace skills dir.
+	internalDest := filepath.Join(workspaceDir, "skills", "sdd-explore", "SKILL.md")
+	if _, err := os.Stat(internalDest); err != nil {
+		t.Errorf("internal skill not installed at %q: %v", internalDest, err)
+	}
+	externalDest := filepath.Join(workspaceDir, "skills", "write-a-prd", "SKILL.md")
+	if _, err := os.Stat(externalDest); err != nil {
+		t.Errorf("external skill not installed at %q: %v", externalDest, err)
+	}
+
+	// External skill should appear in ManagedPaths so uninstall can remove it.
+	foundExternal := false
+	for _, p := range result.ManagedPaths {
+		if p == filepath.Join(workspaceDir, "skills", "write-a-prd") {
+			foundExternal = true
+			break
+		}
+	}
+	if !foundExternal {
+		t.Errorf("external skill dir missing from ManagedPaths; got: %v", result.ManagedPaths)
+	}
+}
+
+// TestClaudeRenderer_InstallWorkflow_ExternalSkillMissingErrors verifies that
+// listing a skill in components.skills that is neither workflow-internal nor a
+// catalog top-level skill produces a clear error.
+func TestClaudeRenderer_InstallWorkflow_ExternalSkillMissingErrors(t *testing.T) {
+	r := renderers.NewClaudeRenderer(claudeAgentDef())
+
+	catalogRoot := t.TempDir()
+	wfCacheDir := filepath.Join(catalogRoot, "workflows", "sdd")
+	if err := os.MkdirAll(wfCacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wfCacheDir, "workflow.yaml"), []byte("apiVersion: devrune/workflow/v1\nmetadata:\n  name: sdd\n  version: 1.0.0\ncomponents:\n  skills:\n    - nonexistent\n"), 0o644); err != nil {
+		t.Fatalf("write workflow.yaml: %v", err)
+	}
+
+	wf := model.WorkflowManifest{
+		APIVersion: "devrune/workflow/v1",
+		Metadata:   model.WorkflowMetadata{Name: "sdd", Version: "1.0.0"},
+		Components: model.WorkflowComponents{Skills: []string{"nonexistent"}},
+	}
+
+	workspaceDir := t.TempDir()
+	_, err := r.InstallWorkflow(wf, wfCacheDir, catalogRoot, workspaceDir)
+	if err == nil {
+		t.Fatal("expected error for missing skill, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should name the missing skill, got: %v", err)
 	}
 }

--- a/internal/materialize/renderers/codex.go
+++ b/internal/materialize/renderers/codex.go
@@ -223,11 +223,14 @@ func (r *CodexRenderer) RenderSettings(_ string, _ []model.ContentItem, _ []mode
 //   - Orchestrator: .agents/skills/<wf-name>-orchestrator/ORCHESTRATOR.md
 //   - _shared: .agents/skills/_shared/
 //   - REGISTRY.md: captured for catalog injection (not copied loose)
-func (r *CodexRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
+func (r *CodexRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, catalogRoot string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
 	skillsSet := make(map[string]bool, len(wf.Components.Skills))
 	for _, s := range wf.Components.Skills {
 		skillsSet[s] = true
 	}
+	// Track skills rendered by the workflow-internal scan so the external pass
+	// only handles names that did NOT appear as subdirectories of the workflow.
+	renderedSkills := make(map[string]bool, len(wf.Components.Skills))
 
 	skillsBase := filepath.Join(workspaceRoot, r.def.SkillDir)
 	workflowDir := filepath.Join(skillsBase, wf.Metadata.EffectiveWorkingDir())
@@ -279,6 +282,7 @@ func (r *CodexRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath str
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: copy skill subdirs for %s: %w", name, err)
 			}
 			managedPaths = append(managedPaths, destDir)
+			renderedSkills[name] = true
 			continue
 		}
 
@@ -306,6 +310,28 @@ func (r *CodexRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath str
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: workflow copy %q: %w", name, err)
 		}
 		managedPaths = append(managedPaths, dstPath)
+	}
+
+	// External skill pass: any name in components.skills that did NOT appear as
+	// a workflow-internal subdirectory is resolved against the catalog root
+	// (catalogRoot/skills/<name>/) and installed under skillsBase like any other
+	// skill.
+	for _, skillName := range wf.Components.Skills {
+		if renderedSkills[skillName] {
+			continue
+		}
+		extSrc, err := ResolveExternalSkillSource(catalogRoot, cachePath, skillName)
+		if err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: %w", err)
+		}
+		extDst := filepath.Join(skillsBase, skillName)
+		if err := r.renderSkillInternal(extSrc, extDst, true); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: external workflow skill %q: %w", skillName, err)
+		}
+		if err := copySkillSubdirs(extSrc, extDst); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("codex: copy skill subdirs for external skill %q: %w", skillName, err)
+		}
+		managedPaths = append(managedPaths, extDst)
 	}
 
 	// Build shared placeholder replacements: {SKILLS_PATH} only.

--- a/internal/materialize/renderers/copilot.go
+++ b/internal/materialize/renderers/copilot.go
@@ -352,7 +352,7 @@ func copilotModelResolver(id string) string { return id }
 // T017: Does NOT install SDD workflow skills to skills/ — they are embedded in .agent.md.
 // T018: Generates native sub-agent .agent.md for each subagent role.
 // T019: Installs orchestrator with proper frontmatter and resolved {SKILLS_PATH}/{SDD_MODEL_*}.
-func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
+func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, catalogRoot string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
 	// Build a set of SDD workflow skills that will become sub-agents (not installed to skills/).
 	subagentSkillSet := make(map[string]bool)
 	for _, role := range wf.Components.Roles {
@@ -366,6 +366,9 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	for _, s := range wf.Components.Skills {
 		skillsSet[s] = true
 	}
+	// Track skills rendered by the workflow-internal scan so the external pass
+	// only handles names that did NOT appear as subdirectories of the workflow.
+	renderedSkills := make(map[string]bool, len(wf.Components.Skills))
 
 	skillsBase := filepath.Join(workspaceRoot, r.def.SkillDir)
 	if err := os.MkdirAll(skillsBase, 0o755); err != nil {
@@ -509,6 +512,7 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: copy skill subdirs for %s: %w", name, err)
 			}
 			managedPaths = append(managedPaths, destDir)
+			renderedSkills[name] = true
 			continue
 		}
 
@@ -532,6 +536,32 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: workflow copy %q: %w", name, err)
 		}
 		managedPaths = append(managedPaths, dstPath)
+	}
+
+	// External skill pass: any name in components.skills that did NOT appear as
+	// a workflow-internal subdirectory is resolved against the catalog root
+	// (catalogRoot/skills/<name>/). Subagent skills and the orchestrator skill
+	// are excluded because Copilot delivers them through agent .agent.md files,
+	// not regular skills/ entries.
+	for _, skillName := range wf.Components.Skills {
+		if renderedSkills[skillName] {
+			continue
+		}
+		if subagentSkillSet[skillName] || skillName == orchRoleName {
+			continue
+		}
+		extSrc, err := ResolveExternalSkillSource(catalogRoot, cachePath, skillName)
+		if err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: %w", err)
+		}
+		extDst := filepath.Join(skillsBase, skillName)
+		if err := r.RenderSkill(extSrc, extDst); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: external workflow skill %q: %w", skillName, err)
+		}
+		if err := copySkillSubdirs(extSrc, extDst); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: copy skill subdirs for external skill %q: %w", skillName, err)
+		}
+		managedPaths = append(managedPaths, extDst)
 	}
 
 	// T018: Generate native sub-agent .agent.md files for each subagent role.

--- a/internal/materialize/renderers/copilot_test.go
+++ b/internal/materialize/renderers/copilot_test.go
@@ -387,7 +387,7 @@ func TestCopilotRenderer_InstallWorkflow_SkillsUnderSkillsDir(t *testing.T) {
 		},
 	}
 
-	result, err := r.InstallWorkflow(wf, cachePath, workspaceRoot)
+	result, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot)
 	if err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
@@ -473,7 +473,7 @@ func TestCopilotRenderer_InstallWorkflow_OrchestratorOnlyInAgentsDir(t *testing.
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, cachePath, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -525,7 +525,7 @@ func TestCopilotRenderer_InstallWorkflow_RegistryInjectedIntoCatalog(t *testing.
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, cachePath, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -656,7 +656,7 @@ func TestCopilotRenderer_InstallWorkflow_ManagedPathsNonEmpty(t *testing.T) {
 		},
 	}
 
-	result, err := r.InstallWorkflow(wf, cachePath, workspaceRoot)
+	result, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot)
 	if err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
@@ -940,7 +940,7 @@ func TestCopilotRenderer_InstallWorkflow_OrchestratorVariant_UsedWhenPresent(t *
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, cachePath, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -988,7 +988,7 @@ func TestCopilotRenderer_InstallWorkflow_OrchestratorVariant_FallsBackToGeneric(
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, cachePath, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1039,7 +1039,7 @@ func TestCopilotRenderer_InstallWorkflow_ForeignVariantNotCopied(t *testing.T) {
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, cachePath, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1561,7 +1561,7 @@ func TestCopilotRenderer_SubAgentToolSets(t *testing.T) {
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, cachePath, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1668,7 +1668,7 @@ When blocked, use ` + "`AskUserQuestion`" + ` to clarify.
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, cachePath, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -2061,7 +2061,7 @@ func TestCopilotRenderer_InstallWorkflow_SharedVariantSuffixStripping(t *testing
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, cachePath, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, cachePath, cachePath, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 

--- a/internal/materialize/renderers/factory.go
+++ b/internal/materialize/renderers/factory.go
@@ -232,11 +232,14 @@ func (r *FactoryRenderer) MCPAgentInstructions() map[string]string {
 //   - _shared: .factory/skills/_shared/
 //   - REGISTRY.md: captured for catalog injection (not copied loose)
 //   - {SKILLS_PATH}: resolved in installed .md files via resolvePlaceholders()
-func (r *FactoryRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
+func (r *FactoryRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, catalogRoot string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
 	skillsSet := make(map[string]bool, len(wf.Components.Skills))
 	for _, s := range wf.Components.Skills {
 		skillsSet[s] = true
 	}
+	// Track skills rendered by the workflow-internal scan so the external pass
+	// only handles names that did NOT appear as subdirectories of the workflow.
+	renderedSkills := make(map[string]bool, len(wf.Components.Skills))
 
 	skillsBase := filepath.Join(workspaceRoot, r.def.SkillDir)
 	workflowDir := filepath.Join(skillsBase, wf.Metadata.EffectiveWorkingDir())
@@ -288,6 +291,7 @@ func (r *FactoryRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: copy skill subdirs for %s: %w", name, err)
 			}
 			managedPaths = append(managedPaths, destDir)
+			renderedSkills[name] = true
 			continue
 		}
 
@@ -315,6 +319,28 @@ func (r *FactoryRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: workflow copy %q: %w", name, err)
 		}
 		managedPaths = append(managedPaths, dstPath)
+	}
+
+	// External skill pass: any name in components.skills that did NOT appear as
+	// a workflow-internal subdirectory is resolved against the catalog root
+	// (catalogRoot/skills/<name>/) and installed under skillsBase like any other
+	// skill.
+	for _, skillName := range wf.Components.Skills {
+		if renderedSkills[skillName] {
+			continue
+		}
+		extSrc, err := ResolveExternalSkillSource(catalogRoot, cachePath, skillName)
+		if err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: %w", err)
+		}
+		extDst := filepath.Join(skillsBase, skillName)
+		if err := r.renderSkillInternal(extSrc, extDst, true); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: external workflow skill %q: %w", skillName, err)
+		}
+		if err := copySkillSubdirs(extSrc, extDst); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("factory: copy skill subdirs for external skill %q: %w", skillName, err)
+		}
+		managedPaths = append(managedPaths, extDst)
 	}
 
 	// Build shared placeholder replacements: {SKILLS_PATH} only.

--- a/internal/materialize/renderers/factory_test.go
+++ b/internal/materialize/renderers/factory_test.go
@@ -353,7 +353,7 @@ func TestFactoryRenderer_InstallWorkflow_SkillsInCorrectLocation(t *testing.T) {
 	wfCacheDir := setupFactoryWorkflowFixture(t)
 	wf := sddWorkflowManifest()
 
-	result, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir)
+	result, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir)
 	if err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
@@ -421,7 +421,7 @@ func TestFactoryRenderer_InstallWorkflow_ManagedPathsNonEmpty(t *testing.T) {
 	wfCacheDir := setupFactoryWorkflowFixture(t)
 	wf := sddWorkflowManifest()
 
-	result, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir)
+	result, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir)
 	if err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestFactoryRenderer_InstallWorkflow_NoDroidsDir(t *testing.T) {
 	wfCacheDir := setupFactoryWorkflowFixture(t)
 	wf := sddWorkflowManifest()
 
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -497,7 +497,7 @@ func TestFactoryRenderer_InstallWorkflow_RegistryInjectedIntoCatalog(t *testing.
 	wfCacheDir := setupFactoryWorkflowFixture(t)
 	wf := sddWorkflowManifest()
 
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -558,7 +558,7 @@ func TestFactoryRenderer_InstallWorkflow_SkillsAreFlat(t *testing.T) {
 	wfCacheDir := setupFactoryWorkflowFixture(t)
 	wf := sddWorkflowManifest()
 
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 

--- a/internal/materialize/renderers/helpers.go
+++ b/internal/materialize/renderers/helpers.go
@@ -28,6 +28,36 @@ var orchestratorVariantNames = map[string]bool{
 	"ORCHESTRATOR.claude.md":   true,
 }
 
+// ResolveExternalSkillSource finds a workflow-declared skill that is NOT a
+// subdirectory of the workflow itself. It looks under the catalog's top-level
+// `skills/<name>/` directory.
+//
+// Used by every renderer's external-skill pass — after the workflow-internal
+// scan loop processes skills that are subdirs of the workflow, anything still
+// listed in `Components.Skills` but not yet rendered is resolved here.
+//
+// Returns the absolute path to the skill directory (containing SKILL.md).
+// Returns an error naming both attempted paths when the skill is missing.
+//
+// catalogRoot is the absolute path to the catalog source root. When it is
+// empty or equals workflowDir, no external lookup is possible and the function
+// returns an error — the caller should not invoke this resolver in that case.
+func ResolveExternalSkillSource(catalogRoot, workflowDir, skillName string) (string, error) {
+	internalGuess := filepath.Join(workflowDir, skillName)
+	if catalogRoot == "" || catalogRoot == workflowDir {
+		return "", fmt.Errorf(
+			"skill %q: not a subdirectory of the workflow (%s) and no catalog root available for external lookup",
+			skillName, internalGuess)
+	}
+	external := filepath.Join(catalogRoot, "skills", skillName)
+	if info, err := os.Stat(filepath.Join(external, "SKILL.md")); err == nil && !info.IsDir() {
+		return external, nil
+	}
+	return "", fmt.Errorf(
+		"skill %q: not found as workflow-internal (%s) or catalog-level (%s)",
+		skillName, internalGuess, external)
+}
+
 // registryVariantNames is the set of agent-specific registry variant filenames.
 // Like orchestrator variants, these must NEVER be copied as loose files into the
 // workspace — each renderer only consumes its own variant (via captureRegistryContent)

--- a/internal/materialize/renderers/helpers_test.go
+++ b/internal/materialize/renderers/helpers_test.go
@@ -1671,3 +1671,107 @@ func TestCopyDirRecursiveStripVariant_SubdirsPassedThrough(t *testing.T) {
 		t.Errorf("nested file %q should be present in dst: %v", nestedPath, err)
 	}
 }
+
+// TestResolveExternalSkillSource_FindsSkillInCatalogRoot verifies that when a
+// skill name is NOT a subdir of the workflow but DOES exist as a top-level
+// catalog skill, the resolver returns the catalog-level path.
+func TestResolveExternalSkillSource_FindsSkillInCatalogRoot(t *testing.T) {
+	catalogRoot := t.TempDir()
+	workflowDir := filepath.Join(catalogRoot, "workflows", "sdd")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflowDir: %v", err)
+	}
+	skillDir := filepath.Join(catalogRoot, "skills", "write-a-prd")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skillDir: %v", err)
+	}
+	skillMD := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillMD, []byte("---\nname: write-a-prd\n---\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	got, err := renderers.ResolveExternalSkillSource(catalogRoot, workflowDir, "write-a-prd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != skillDir {
+		t.Errorf("got %q, want %q", got, skillDir)
+	}
+}
+
+// TestResolveExternalSkillSource_MissingSkillReturnsClearError verifies that
+// when the skill name is not found anywhere, the error names BOTH attempted
+// paths so the contributor can act on it.
+func TestResolveExternalSkillSource_MissingSkillReturnsClearError(t *testing.T) {
+	catalogRoot := t.TempDir()
+	workflowDir := filepath.Join(catalogRoot, "workflows", "sdd")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	_, err := renderers.ResolveExternalSkillSource(catalogRoot, workflowDir, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"nonexistent", "workflow-internal", "catalog-level"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message %q should contain %q", msg, want)
+		}
+	}
+}
+
+// TestResolveExternalSkillSource_NoCatalogRoot verifies that when catalogRoot
+// is empty (standalone workflow with no parent catalog), the resolver returns
+// an error WITHOUT attempting an external lookup it cannot perform.
+func TestResolveExternalSkillSource_NoCatalogRoot(t *testing.T) {
+	workflowDir := t.TempDir()
+
+	_, err := renderers.ResolveExternalSkillSource("", workflowDir, "write-a-prd")
+	if err == nil {
+		t.Fatal("expected error when catalogRoot is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "no catalog root available") {
+		t.Errorf("error message should mention missing catalog root, got: %v", err)
+	}
+}
+
+// TestResolveExternalSkillSource_CatalogRootEqualsWorkflowDir verifies that
+// when catalogRoot == workflowDir (standalone workflow archive packaged at
+// root), the resolver still returns an error for unknown skills — there is no
+// separate parent catalog to search.
+func TestResolveExternalSkillSource_CatalogRootEqualsWorkflowDir(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := renderers.ResolveExternalSkillSource(dir, dir, "write-a-prd")
+	if err == nil {
+		t.Fatal("expected error when catalogRoot == workflowDir, got nil")
+	}
+	if !strings.Contains(err.Error(), "no catalog root available") {
+		t.Errorf("error message should mention missing catalog root, got: %v", err)
+	}
+}
+
+// TestResolveExternalSkillSource_RequiresSKILLmd verifies the resolver checks
+// for an actual SKILL.md inside the candidate directory — not just the dir
+// existing — so empty placeholder dirs don't trigger false positives.
+func TestResolveExternalSkillSource_RequiresSKILLmd(t *testing.T) {
+	catalogRoot := t.TempDir()
+	workflowDir := filepath.Join(catalogRoot, "workflows", "sdd")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Create the candidate skill dir but WITHOUT a SKILL.md.
+	emptyDir := filepath.Join(catalogRoot, "skills", "write-a-prd")
+	if err := os.MkdirAll(emptyDir, 0o755); err != nil {
+		t.Fatalf("mkdir empty skill dir: %v", err)
+	}
+
+	_, err := renderers.ResolveExternalSkillSource(catalogRoot, workflowDir, "write-a-prd")
+	if err == nil {
+		t.Fatal("expected error when SKILL.md is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error message should mention 'not found', got: %v", err)
+	}
+}

--- a/internal/materialize/renderers/opencode.go
+++ b/internal/materialize/renderers/opencode.go
@@ -279,11 +279,14 @@ func (r *OpenCodeRenderer) MCPAgentInstructions() map[string]string {
 // NOT created:
 //   - agents/ directory (redundant — agent entries go into opencode.json)
 //   - commands/ directory (empty; not needed by OpenCode)
-func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
+func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath string, catalogRoot string, workspaceRoot string) (matypes.WorkflowInstallResult, error) {
 	skillsSet := make(map[string]bool, len(wf.Components.Skills))
 	for _, s := range wf.Components.Skills {
 		skillsSet[s] = true
 	}
+	// Track skills rendered by the workflow-internal scan so the external pass
+	// only handles names that did NOT appear as subdirectories of the workflow.
+	renderedSkills := make(map[string]bool, len(wf.Components.Skills))
 
 	skillsBase := filepath.Join(workspaceRoot, r.def.SkillDir)
 	// OpenCode installs workflow files (orchestrator, _shared) in its own workspace
@@ -352,6 +355,7 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: copy skill subdirs for %s: %w", name, err)
 			}
 			managedPaths = append(managedPaths, destDir)
+			renderedSkills[name] = true
 			continue
 		}
 
@@ -385,6 +389,33 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: workflow copy %q: %w", name, err)
 		}
 		managedPaths = append(managedPaths, dstPath)
+	}
+
+	// External skill pass: any name in components.skills that did NOT appear as
+	// a workflow-internal subdirectory is resolved against the catalog root
+	// (catalogRoot/skills/<name>/). The orchestrator skill name is excluded
+	// because OpenCode delivers the orchestrator as a primary agent in
+	// opencode.json, not as a regular skill — its absence from the workflow dir
+	// must NOT trigger an external lookup.
+	for _, skillName := range wf.Components.Skills {
+		if renderedSkills[skillName] {
+			continue
+		}
+		if skillName == wf.Metadata.EffectiveWorkingDir() {
+			continue
+		}
+		extSrc, err := ResolveExternalSkillSource(catalogRoot, cachePath, skillName)
+		if err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: %w", err)
+		}
+		extDst := filepath.Join(skillsBase, skillName)
+		if err := r.RenderSkill(extSrc, extDst); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: external workflow skill %q: %w", skillName, err)
+		}
+		if err := copySkillSubdirs(extSrc, extDst); err != nil {
+			return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: copy skill subdirs for external skill %q: %w", skillName, err)
+		}
+		managedPaths = append(managedPaths, extDst)
 	}
 
 	// Build shared placeholder replacements: {SKILLS_PATH} and {SDD_MODEL_*}.

--- a/internal/materialize/renderers/opencode_test.go
+++ b/internal/materialize/renderers/opencode_test.go
@@ -446,7 +446,7 @@ func TestOpenCodeRenderer_InstallWorkflow_SkillsUnderSkillsDir(t *testing.T) {
 	wfCacheDir := buildSddWorkflowCache(t, "# SDD Orchestrator\n\nCoordinates SDD.\n")
 	wf := sddParityManifest()
 
-	result, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir)
+	result, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir)
 	if err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
@@ -514,7 +514,7 @@ func TestOpenCodeRenderer_InstallWorkflow_AgentEntriesInOpencodeJSON(t *testing.
 	wfCacheDir := buildSddWorkflowCache(t, orchContent)
 	wf := sddParityManifest()
 
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -586,7 +586,7 @@ func TestOpenCodeRenderer_InstallWorkflow_ModelResolvedInAgentEntry(t *testing.T
 	wfCacheDir := buildSddWorkflowCache(t, "# SDD Orchestrator\n\nCoordinates SDD.\n")
 	wf := sddParityManifest()
 
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -631,7 +631,7 @@ func TestOpenCodeRenderer_InstallWorkflow_NoAgentsDirCreated(t *testing.T) {
 	wfCacheDir := buildSddWorkflowCache(t, "# SDD Orchestrator\n\nCoordinates SDD.\n")
 	wf := sddParityManifest()
 
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -702,7 +702,7 @@ components:
 		},
 	}
 
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -748,7 +748,7 @@ func TestOpenCodeRenderer_InstallWorkflow_ManagedPathsNonEmpty(t *testing.T) {
 	wfCacheDir := buildSddWorkflowCache(t, "# SDD Orchestrator\n\nCoordinates SDD.\n")
 	wf := sddParityManifest()
 
-	result, err := r.InstallWorkflow(wf, wfCacheDir, workspaceRoot)
+	result, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceRoot)
 	if err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
@@ -1206,7 +1206,7 @@ func TestOpenCodeRenderer_InstallWorkflow_OrchestratorVariant_UsedWhenPresent(t 
 		t.Fatalf("write variant: %v", err)
 	}
 
-	if _, err := r.InstallWorkflow(sddParityManifest(), wfCacheDir, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(sddParityManifest(), wfCacheDir, wfCacheDir, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1262,7 +1262,7 @@ func TestOpenCodeRenderer_InstallWorkflow_OrchestratorVariant_FallsBackToGeneric
 	// No variant file — only the generic ORCHESTRATOR.md is present.
 	wfCacheDir := buildSddWorkflowCache(t, genericContent)
 
-	if _, err := r.InstallWorkflow(sddParityManifest(), wfCacheDir, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(sddParityManifest(), wfCacheDir, wfCacheDir, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1321,7 +1321,7 @@ func TestOpenCodeRenderer_InstallWorkflow_ForeignVariantNotCopied(t *testing.T) 
 		t.Fatalf("write copilot variant: %v", err)
 	}
 
-	if _, err := r.InstallWorkflow(sddParityManifest(), wfCacheDir, workspaceRoot); err != nil {
+	if _, err := r.InstallWorkflow(sddParityManifest(), wfCacheDir, wfCacheDir, workspaceRoot); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
@@ -1436,7 +1436,7 @@ func TestOpenCodeRenderer_InstallWorkflow_SharedVariantSuffixStripping(t *testin
 	}
 
 	wf := sddParityManifest()
-	if _, err := r.InstallWorkflow(wf, wfCacheDir, workspaceDir); err != nil {
+	if _, err := r.InstallWorkflow(wf, wfCacheDir, wfCacheDir, workspaceDir); err != nil {
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 

--- a/internal/materialize/renderers/sdd_role_invariant_test.go
+++ b/internal/materialize/renderers/sdd_role_invariant_test.go
@@ -145,7 +145,7 @@ func TestSDDRoleInvariant_SurvivesRendering(t *testing.T) {
 		r := renderers.NewClaudeRenderer(claudeNativeAgentDef())
 		cache := writeSDDOrchestratorCacheWithRoleInvariant(t, "claude")
 		workspace := t.TempDir()
-		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, workspace); err != nil {
+		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, cache, workspace); err != nil {
 			t.Fatalf("InstallWorkflow: %v", err)
 		}
 		path := filepath.Join(workspace, "skills", "sdd-orchestrator", "ORCHESTRATOR.md")
@@ -172,7 +172,7 @@ func TestSDDRoleInvariant_SurvivesRendering(t *testing.T) {
 		}
 		r := renderers.NewCodexRenderer(def)
 		cache := writeSDDOrchestratorCacheWithRoleInvariant(t, "")
-		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, workspaceDir); err != nil {
+		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, cache, workspaceDir); err != nil {
 			t.Fatalf("InstallWorkflow: %v", err)
 		}
 		path := filepath.Join(projectRoot, ".agents", "skills", "sdd-orchestrator", "ORCHESTRATOR.md")
@@ -199,7 +199,7 @@ func TestSDDRoleInvariant_SurvivesRendering(t *testing.T) {
 		}
 		r := renderers.NewFactoryRenderer(def)
 		cache := writeSDDOrchestratorCacheWithRoleInvariant(t, "")
-		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, workspaceDir); err != nil {
+		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, cache, workspaceDir); err != nil {
 			t.Fatalf("InstallWorkflow: %v", err)
 		}
 		path := filepath.Join(projectRoot, ".agents", "skills", "sdd-orchestrator", "ORCHESTRATOR.md")
@@ -223,7 +223,7 @@ func TestSDDRoleInvariant_SurvivesRendering(t *testing.T) {
 		}
 		r := renderers.NewCopilotRenderer(def)
 		cache := writeSDDOrchestratorCacheWithRoleInvariant(t, "copilot")
-		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, workspaceRoot); err != nil {
+		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, cache, workspaceRoot); err != nil {
 			t.Fatalf("InstallWorkflow: %v", err)
 		}
 		path := filepath.Join(workspaceRoot, "agents", "sdd-orchestrator.agent.md")
@@ -251,7 +251,7 @@ func TestSDDRoleInvariant_SurvivesRendering(t *testing.T) {
 		}
 		r := renderers.NewOpenCodeRenderer(def)
 		cache := writeSDDOrchestratorCacheWithRoleInvariant(t, "opencode")
-		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, workspaceDir); err != nil {
+		if _, err := r.InstallWorkflow(sddTestWorkflowForRoleInvariant(), cache, cache, workspaceDir); err != nil {
 			t.Fatalf("InstallWorkflow: %v", err)
 		}
 		// OpenCode inlines ORCHESTRATOR content into opencode.json under

--- a/internal/model/workflow.go
+++ b/internal/model/workflow.go
@@ -95,9 +95,21 @@ type WorkflowRole struct {
 // The workflow directory is the atomic unit — everything in it gets materialized.
 // This struct only declares which parts need special handling.
 type WorkflowComponents struct {
-	// Skills lists subdirectory names within the workflow directory that require
-	// frontmatter transformation via AgentRenderer.RenderSkill().
-	// All other files and directories are materialized as-is.
+	// Skills lists skill names this workflow needs. Each renderer resolves a
+	// name in two steps:
+	//   1. Workflow-internal: subdirectory of the workflow directory
+	//      (e.g. "<workflow-dir>/<name>/SKILL.md"). Used for skills shipped
+	//      alongside the workflow (e.g. SDD's sdd-explore, sdd-plan).
+	//   2. Catalog-level fallback: top-level skill directory of the catalog
+	//      (e.g. "<catalog-root>/skills/<name>/SKILL.md"). Used for shared,
+	//      reusable skills the workflow depends on but doesn't own
+	//      (e.g. SDD's PRD gate invokes write-a-prd, which lives at
+	//      catalog/skills/write-a-prd/, not under the SDD workflow).
+	// Internal-pass skills get rendered first; anything still listed but not
+	// yet rendered triggers the catalog-level resolver. Missing skills produce
+	// a clear error naming both attempted paths.
+	// All non-skill files and directories under the workflow dir are
+	// materialized as-is.
 	Skills []string `yaml:"skills"`
 
 	// Entrypoint is the file path (relative to workflow directory) of the


### PR DESCRIPTION
Closes #63.

## Summary

Lifts the constraint that every entry in `workflow.yaml`'s `components.skills` must be a subdirectory of the workflow itself. Skills can now live at the catalog top level (`catalog/skills/<name>/`) and still be declared as workflow dependencies — the renderer resolves them automatically.

## Why

SDD's PRD gate invokes `Skill(\"write-a-prd\")` at workflow start. \`write-a-prd\` lives at \`catalog/skills/write-a-prd/\`, not under \`catalog/workflows/sdd/\`. Before this change, the SDD workflow could not list it as a dependency, so users had to remember to add it to their \`devrune.yaml\` package select; if they forgot, SDD failed the moment the PRD gate fired.

## Resolution order (per skill name in \`components.skills\`)

1. **Workflow-internal**: \`<workflow-dir>/<name>/SKILL.md\` (existing behavior)
2. **Catalog-level fallback**: \`<catalog-root>/skills/<name>/SKILL.md\` (new)
3. Missing in both → error naming both attempted paths

## What changed

| File | Change |
|---|---|
| \`internal/materialize/renderer.go\` | \`InstallWorkflow\` interface gains a 4th parameter \`catalogRoot string\` |
| \`internal/materialize/materializer.go\` | Passes the cached package root as \`catalogRoot\` to every renderer |
| \`internal/materialize/renderers/helpers.go\` | New \`ResolveExternalSkillSource(catalogRoot, workflowDir, skillName)\` helper |
| \`internal/materialize/renderers/{claude,opencode,copilot,factory,codex}.go\` | Existing scan loop unchanged for workflow-internal skills; new follow-up pass handles names listed in \`Components.Skills\` that didn't appear as workflow subdirs |
| \`internal/model/workflow.go\` | Godoc on \`Components.Skills\` describes dual-location resolution |

Copilot and OpenCode renderers exclude orchestrator/sub-agent skills from the external pass since those are delivered as agent files, not regular skills.

## Tests

- 5 helper tests (\`helpers_test.go\`): catalog-root resolution success, missing skill error wording, empty catalog root, catalog root equals workflow dir, SKILL.md required (not just dir).
- 2 Claude integration tests (\`claude_test.go\`): external skill lands in workspace + ManagedPaths; missing external skill produces clear error.
- Existing tests updated to pass \`catalogRoot\` (mostly equal to \`cachePath\` in unit tests, exercising the workflow-internal path unchanged).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` all green
- [ ] After merge: catalog adds \`write-a-prd\` to SDD's \`workflow.yaml\` \`components.skills\`. Re-install on a workspace that does NOT explicitly select \`write-a-prd\` and confirm it lands in \`.claude/skills/write-a-prd/\`.

## Out of scope

- Cross-package skill dependencies (skill living in a different catalog source). Resolution stays local to the active catalog cache, as documented in the issue.
- Renaming or restructuring \`components.skills\` semantically. Same field, broader resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)