### PR TITLE
fix(tui)!: per-agent role models in workflow.yaml + canonical SDD preload

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -529,7 +529,10 @@ components:
     - name: sdd-planner
       kind: subagent
       skill: sdd-plan
-      model: sonnet
+      models:
+        claude: sonnet
+        opencode: sonnet
+        copilot: Claude Sonnet 4.6
     - name: sdd-orchestrator
       kind: orchestrator
 `

--- a/internal/materialize/renderers/claude.go
+++ b/internal/materialize/renderers/claude.go
@@ -554,7 +554,7 @@ func (r *ClaudeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath st
 	// Passing nil for modelResolver keeps bare short names (e.g. "sonnet", "opus") in
 	// the agent-file frontmatter — Claude Code expects short IDs, not the "anthropic/..."
 	// form produced by resolveModel().
-	replacements := buildWorkflowPlaceholderReplacements(wf, r.def.Workspace, r.def.SkillDir, nil, r.modelOverrides, nil)
+	replacements := buildWorkflowPlaceholderReplacements(wf, r.def.Workspace, r.def.SkillDir, "claude", nil, r.modelOverrides, nil)
 	// Overwrite subagent placeholders with native role names (Claude-native uses
 	// Agent(subagent_type: 'sdd-explorer', ...) rather than a generic type).
 	for _, role := range wf.Components.Roles {

--- a/internal/materialize/renderers/claude_test.go
+++ b/internal/materialize/renderers/claude_test.go
@@ -622,10 +622,10 @@ Review model: {SDD_MODEL_REVIEW}
 		Components: model.WorkflowComponents{
 			Entrypoint: "ORCHESTRATOR.md",
 			Roles: []model.WorkflowRole{
-				{Name: "sdd-explorer", Kind: "subagent", Model: "sonnet"},
-				{Name: "sdd-planner", Kind: "subagent", Model: "opus"},
-				{Name: "sdd-implementer", Kind: "subagent", Model: "sonnet"},
-				{Name: "sdd-reviewer", Kind: "subagent", Model: "haiku"},
+				{Name: "sdd-explorer", Kind: "subagent", Models: map[string]string{"claude": "sonnet"}},
+				{Name: "sdd-planner", Kind: "subagent", Models: map[string]string{"claude": "opus"}},
+				{Name: "sdd-implementer", Kind: "subagent", Models: map[string]string{"claude": "sonnet"}},
+				{Name: "sdd-reviewer", Kind: "subagent", Models: map[string]string{"claude": "haiku"}},
 			},
 		},
 	}
@@ -1352,12 +1352,12 @@ func sddTestWorkflow() model.WorkflowManifest {
 			Skills:     []string{"sdd-explore", "sdd-plan", "sdd-implement", "sdd-review"},
 			Entrypoint: "ORCHESTRATOR.md",
 			Roles: []model.WorkflowRole{
-				{Name: "sdd-explorer", Kind: "subagent", Skill: "sdd-explore", Model: "sonnet"},
-				{Name: "sdd-planner", Kind: "subagent", Skill: "sdd-plan", Model: "opus"},
-				{Name: "sdd-implementer", Kind: "subagent", Skill: "sdd-implement", Model: "sonnet"},
-				{Name: "sdd-reviewer", Kind: "subagent", Skill: "sdd-review", Model: "opus"},
+				{Name: "sdd-explorer", Kind: "subagent", Skill: "sdd-explore", Models: map[string]string{"claude": "sonnet", "opencode": "sonnet", "copilot": "Claude Sonnet 4.6"}},
+				{Name: "sdd-planner", Kind: "subagent", Skill: "sdd-plan", Models: map[string]string{"claude": "opus", "opencode": "opus", "copilot": "Claude Opus 4.6"}},
+				{Name: "sdd-implementer", Kind: "subagent", Skill: "sdd-implement", Models: map[string]string{"claude": "sonnet", "opencode": "sonnet", "copilot": "Claude Sonnet 4.6"}},
+				{Name: "sdd-reviewer", Kind: "subagent", Skill: "sdd-review", Models: map[string]string{"claude": "opus", "opencode": "opus", "copilot": "Claude Opus 4.6"}},
 				{Name: "sdd-orchestrator", Kind: "orchestrator"},
-				{Name: "sdd-advisor", Kind: "subagent", Skill: "*-advisor", Model: "opus"},
+				{Name: "sdd-advisor", Kind: "subagent", Skill: "*-advisor", Models: map[string]string{"claude": "opus", "opencode": "opus", "copilot": "Claude Opus 4.6"}},
 			},
 		},
 	}

--- a/internal/materialize/renderers/copilot.go
+++ b/internal/materialize/renderers/copilot.go
@@ -415,11 +415,12 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 	skillDirName := r.def.SkillDir
 	replacements := buildWorkflowPlaceholderReplacements(
 		wf, workspaceRoot, skillDirName,
+		"copilot",
 		copilotModelResolver, // identity: bare ID passes through unchanged to .agent.md frontmatter
-		                      // DO NOT use resolveModel here — that produces "anthropic/..." format,
-		                      // which is invalid for Copilot .agent.md frontmatter.
-		r.modelOverrides,     // TUI-selected per-role bare model IDs from CopilotModelOptions()
-		nil,                  // no custom subagent resolver; Copilot uses native @agent-name
+		// DO NOT use resolveModel here — that produces "anthropic/..." format,
+		// which is invalid for Copilot .agent.md frontmatter.
+		r.modelOverrides, // TUI-selected per-role bare model IDs from CopilotModelOptions()
+		nil,              // no custom subagent resolver; Copilot uses native @agent-name
 	)
 	// Override subagent placeholders to use role names (Copilot has native .agent.md agents).
 	// buildWorkflowPlaceholderReplacements with subagentResolver=nil defaults subagent entries
@@ -744,13 +745,13 @@ func (r *CopilotRenderer) generateSubAgentFile(skillSrcDir, dstPath string, role
 	}
 
 	// Add model: prefer TUI-selected override from replacements (pre-resolved via copilotModelResolver),
-	// fall back to bare role.Model. Never use resolveModel() — that produces "anthropic/..." format
+	// fall back to role.Models["copilot"]. Never use resolveModel() — that produces "anthropic/..." format
 	// which is invalid for Copilot .agent.md frontmatter.
 	placeholderKey := "{WORKFLOW_MODEL_" + model.PlaceholderKeyFromRole(wf.Metadata.Name, role.Name, role.Placeholder) + "}"
 	if modelVal, ok := replacements[placeholderKey]; ok && modelVal != "" {
 		fm["model"] = modelVal
-	} else if role.Model != "" {
-		fm["model"] = copilotModelResolver(role.Model)
+	} else if m := role.ModelFor("copilot"); m != "" {
+		fm["model"] = copilotModelResolver(m)
 	}
 
 	out, err := parse.SerializeFrontmatter(fm, bodyContent)

--- a/internal/materialize/renderers/export_test.go
+++ b/internal/materialize/renderers/export_test.go
@@ -14,10 +14,11 @@ var BuildWorkflowPlaceholderReplacements = func(
 	wf model.WorkflowManifest,
 	workspaceDir string,
 	skillDir string,
+	agentName string,
 	modelResolver func(string) string,
 	modelOverrides map[string]string,
 ) map[string]string {
-	return buildWorkflowPlaceholderReplacements(wf, workspaceDir, skillDir, modelResolver, modelOverrides, nil)
+	return buildWorkflowPlaceholderReplacements(wf, workspaceDir, skillDir, agentName, modelResolver, modelOverrides, nil)
 }
 
 // BuildWorkflowPathReplacements re-exports buildWorkflowPathReplacements

--- a/internal/materialize/renderers/helpers.go
+++ b/internal/materialize/renderers/helpers.go
@@ -753,25 +753,32 @@ func resolveMCPDefDir(cacheRoot, dir string) string {
 //   - Auto-derived: strip "<workflowName>-" prefix, uppercase, hyphens → underscores
 //   - Explicit: role.Placeholder overrides auto-derivation
 //
+// agentName selects which entry of role.Models is consulted as the workflow.yaml
+// default (e.g. "claude", "opencode", "copilot"). Pass an empty string to skip
+// the workflow.yaml fallback entirely; the role then only receives a placeholder
+// when modelOverrides supplies one.
+//
 // modelResolver is an optional function that maps a raw model value to the
 // fully qualified ID expected by the target platform. When nil, the raw
-// role.Model value is used as-is — needed for Claude Code where the Agent
+// role model value is used as-is — needed for Claude Code where the Agent
 // tool expects short names ("sonnet", "opus", "haiku"). Typical values:
 //   - nil              → raw short names (Claude Code)
 //   - resolveModel     → anthropic/... format (Factory, Copilot)
 //   - resolveOpenCodeModel → github-copilot/... format (OpenCode)
 //
 // modelOverrides is an optional map of role-name → model-value. When non-nil,
-// an override for a role takes precedence over the role's own Model field from
-// workflow.yaml. The ModelInheritOption sentinel is treated as "no override"
-// (falls back to role.Model). Passing nil is fully backward-compatible.
+// an override for a role takes precedence over the workflow.yaml value. The
+// ModelInheritOption sentinel is treated as "no override" (falls back to
+// role.Models[agentName]). Passing nil is fully backward-compatible.
 //
-// Model placeholders are only added when the corresponding role has a non-empty Model field.
-// workspaceDir and skillDir must not have trailing slashes; the helper joins them cleanly.
+// Model placeholders are only added when a model value can be resolved (override
+// or workflow.yaml). workspaceDir and skillDir must not have trailing slashes;
+// the helper joins them cleanly.
 func buildWorkflowPlaceholderReplacements(
 	wf model.WorkflowManifest,
 	workspaceDir string,
 	skillDir string,
+	agentName string,
 	modelResolver func(string) string,
 	modelOverrides map[string]string,
 	subagentResolver func(roleName string) string,
@@ -825,15 +832,15 @@ func buildWorkflowPlaceholderReplacements(
 		}
 		replacements["{WORKFLOW_SUBAGENT_"+key+"}"] = subagentType
 
-		// Check TUI-selected override first, then fall back to role.Model from workflow.yaml.
+		// Check TUI-selected override first, then fall back to role.Models[agentName] from workflow.yaml.
 		modelValue := ""
 		if modelOverrides != nil {
 			if v, ok := modelOverrides[role.Name]; ok && v != "" && v != model.ModelInheritOption {
 				modelValue = v
 			}
 		}
-		if modelValue == "" && role.Model != "" {
-			modelValue = role.Model
+		if modelValue == "" && agentName != "" {
+			modelValue = role.ModelFor(agentName)
 		}
 		if modelValue == "" {
 			continue

--- a/internal/materialize/renderers/helpers_test.go
+++ b/internal/materialize/renderers/helpers_test.go
@@ -731,16 +731,16 @@ func makeWFWithRoles(roles []model.WorkflowRole) model.WorkflowManifest {
 }
 
 // TestBuildWorkflowPlaceholderReplacements_OverrideTakesPrecedence verifies that a
-// value in modelOverrides replaces the role.Model from workflow.yaml.
+// value in modelOverrides replaces the per-agent yaml default from role.Models.
 func TestBuildWorkflowPlaceholderReplacements_OverrideTakesPrecedence(t *testing.T) {
 	wf := makeWFWithRoles([]model.WorkflowRole{
-		{Name: "sdd-explorer", Kind: "subagent", Model: "haiku"},
+		{Name: "sdd-explorer", Kind: "subagent", Models: map[string]string{"claude": "haiku"}},
 	})
 	overrides := map[string]string{
 		"sdd-explorer": "sonnet",
 	}
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, overrides)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, overrides)
 
 	got := result["{SDD_MODEL_EXPLORE}"]
 	if got != "sonnet" {
@@ -748,35 +748,35 @@ func TestBuildWorkflowPlaceholderReplacements_OverrideTakesPrecedence(t *testing
 	}
 }
 
-// TestBuildWorkflowPlaceholderReplacements_InheritSentinelFallsBackToRoleModel verifies
-// that the SDDModelInheritOption sentinel in overrides is treated as "no override",
-// causing fallback to role.Model.
-func TestBuildWorkflowPlaceholderReplacements_InheritSentinelFallsBackToRoleModel(t *testing.T) {
+// TestBuildWorkflowPlaceholderReplacements_InheritSentinelFallsBackToYaml verifies
+// that the ModelInheritOption sentinel in overrides is treated as "no override",
+// causing fallback to role.Models[agent].
+func TestBuildWorkflowPlaceholderReplacements_InheritSentinelFallsBackToYaml(t *testing.T) {
 	wf := makeWFWithRoles([]model.WorkflowRole{
-		{Name: "sdd-planner", Kind: "subagent", Model: "opus"},
+		{Name: "sdd-planner", Kind: "subagent", Models: map[string]string{"claude": "opus"}},
 	})
 	overrides := map[string]string{
 		"sdd-planner": model.ModelInheritOption, // sentinel = no override
 	}
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, overrides)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, overrides)
 
 	got := result["{SDD_MODEL_PLAN}"]
 	if got != "opus" {
-		t.Errorf("{SDD_MODEL_PLAN} = %q, want %q (inherit sentinel should fall back to role.Model)", got, "opus")
+		t.Errorf("{SDD_MODEL_PLAN} = %q, want %q (inherit sentinel should fall back to role.Models[agent])", got, "opus")
 	}
 }
 
 // TestBuildWorkflowPlaceholderReplacements_EmptyOverrideMapIsBackwardCompatible verifies
-// that an empty (non-nil) override map behaves the same as nil — role.Model is used.
+// that an empty (non-nil) override map behaves the same as nil — yaml value is used.
 func TestBuildWorkflowPlaceholderReplacements_EmptyOverrideMapIsBackwardCompatible(t *testing.T) {
 	wf := makeWFWithRoles([]model.WorkflowRole{
-		{Name: "sdd-implementer", Kind: "subagent", Model: "sonnet"},
+		{Name: "sdd-implementer", Kind: "subagent", Models: map[string]string{"claude": "sonnet"}},
 	})
 	emptyOverrides := map[string]string{}
 
-	resultWithEmpty := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, emptyOverrides)
-	resultWithNil := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, nil)
+	resultWithEmpty := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, emptyOverrides)
+	resultWithNil := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, nil)
 
 	if resultWithEmpty["{SDD_MODEL_IMPLEMENT}"] != resultWithNil["{SDD_MODEL_IMPLEMENT}"] {
 		t.Errorf("empty override map produced %q, nil produced %q — should be equal",
@@ -784,14 +784,14 @@ func TestBuildWorkflowPlaceholderReplacements_EmptyOverrideMapIsBackwardCompatib
 	}
 }
 
-// TestBuildWorkflowPlaceholderReplacements_NilOverridesIsBackwardCompatible verifies that
-// nil modelOverrides does not change any existing placeholder behaviour.
-func TestBuildWorkflowPlaceholderReplacements_NilOverridesIsBackwardCompatible(t *testing.T) {
+// TestBuildWorkflowPlaceholderReplacements_NilOverridesUsesYamlValue verifies that
+// nil modelOverrides falls back to the per-agent yaml value.
+func TestBuildWorkflowPlaceholderReplacements_NilOverridesUsesYamlValue(t *testing.T) {
 	wf := makeWFWithRoles([]model.WorkflowRole{
-		{Name: "sdd-reviewer", Kind: "subagent", Model: "haiku"},
+		{Name: "sdd-reviewer", Kind: "subagent", Models: map[string]string{"claude": "haiku"}},
 	})
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, nil)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, nil)
 
 	got := result["{SDD_MODEL_REVIEW}"]
 	if got != "haiku" {
@@ -803,13 +803,13 @@ func TestBuildWorkflowPlaceholderReplacements_NilOverridesIsBackwardCompatible(t
 // when a modelResolver is provided, a short-name override is resolved to the full model ID.
 func TestBuildWorkflowPlaceholderReplacements_OverrideWithResolveModelsTrue(t *testing.T) {
 	wf := makeWFWithRoles([]model.WorkflowRole{
-		{Name: "sdd-explorer", Kind: "subagent", Model: "haiku"},
+		{Name: "sdd-explorer", Kind: "subagent", Models: map[string]string{"claude": "haiku"}},
 	})
 	overrides := map[string]string{
 		"sdd-explorer": "sonnet",
 	}
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", renderers.ResolveModel, overrides)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", renderers.ResolveModel, overrides)
 
 	got := result["{SDD_MODEL_EXPLORE}"]
 	wantPrefix := "anthropic/claude-sonnet" // full ID starts with this
@@ -825,13 +825,13 @@ func TestBuildWorkflowPlaceholderReplacements_OverrideWithResolveModelsTrue(t *t
 // when modelResolver is nil, the raw override value is used as-is without resolution.
 func TestBuildWorkflowPlaceholderReplacements_OverrideWithResolveModelsFalse(t *testing.T) {
 	wf := makeWFWithRoles([]model.WorkflowRole{
-		{Name: "sdd-planner", Kind: "subagent", Model: "opus"},
+		{Name: "sdd-planner", Kind: "subagent", Models: map[string]string{"claude": "opus"}},
 	})
 	overrides := map[string]string{
 		"sdd-planner": "sonnet",
 	}
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, overrides)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, overrides)
 
 	got := result["{SDD_MODEL_PLAN}"]
 	if got != "sonnet" {
@@ -889,10 +889,10 @@ func TestResolveOpenCodeModel_UnknownBareNameGetsPrefixed(t *testing.T) {
 // resolveOpenCodeModel produces github-copilot/... format placeholders.
 func TestBuildWorkflowPlaceholderReplacements_OpenCodeResolver(t *testing.T) {
 	wf := makeWFWithRoles([]model.WorkflowRole{
-		{Name: "sdd-explorer", Kind: "subagent", Model: "sonnet"},
+		{Name: "sdd-explorer", Kind: "subagent", Models: map[string]string{"opencode": "sonnet"}},
 	})
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", renderers.ResolveOpenCodeModel, nil)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "opencode", renderers.ResolveOpenCodeModel, nil)
 
 	got := result["{SDD_MODEL_EXPLORE}"]
 	const want = "github-copilot/claude-sonnet-4.6"
@@ -1111,10 +1111,10 @@ func contains(s, sub string) bool {
 // workflows emit both {WORKFLOW_MODEL_*} and legacy {SDD_MODEL_*} placeholders.
 func TestBuildWorkflowPlaceholderReplacements_SDDEmitsBothFormats(t *testing.T) {
 	wf := makeWFWithRoles([]model.WorkflowRole{
-		{Name: "sdd-explorer", Kind: "subagent", Model: "sonnet"},
+		{Name: "sdd-explorer", Kind: "subagent", Models: map[string]string{"claude": "sonnet"}},
 	})
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, nil)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, nil)
 
 	// New format.
 	if got := result["{WORKFLOW_MODEL_EXPLORER}"]; got != "sonnet" {
@@ -1132,11 +1132,11 @@ func TestBuildWorkflowPlaceholderReplacements_NonSDDWorkflow(t *testing.T) {
 	var wf model.WorkflowManifest
 	wf.Metadata.Name = "code-review"
 	wf.Components.Roles = []model.WorkflowRole{
-		{Name: "reviewer", Kind: "subagent", Model: "opus"},
-		{Name: "code-review-checker", Kind: "subagent", Model: "sonnet"},
+		{Name: "reviewer", Kind: "subagent", Models: map[string]string{"claude": "opus"}},
+		{Name: "code-review-checker", Kind: "subagent", Models: map[string]string{"claude": "sonnet"}},
 	}
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, nil)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, nil)
 
 	if got := result["{WORKFLOW_MODEL_REVIEWER}"]; got != "opus" {
 		t.Errorf("{WORKFLOW_MODEL_REVIEWER} = %q, want %q", got, "opus")
@@ -1158,10 +1158,10 @@ func TestBuildWorkflowPlaceholderReplacements_ExplicitPlaceholder(t *testing.T) 
 	var wf model.WorkflowManifest
 	wf.Metadata.Name = "cicd"
 	wf.Components.Roles = []model.WorkflowRole{
-		{Name: "code-quality-checker", Kind: "subagent", Model: "haiku", Placeholder: "CHECKER"},
+		{Name: "code-quality-checker", Kind: "subagent", Models: map[string]string{"claude": "haiku"}, Placeholder: "CHECKER"},
 	}
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, nil)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, nil)
 
 	if got := result["{WORKFLOW_MODEL_CHECKER}"]; got != "haiku" {
 		t.Errorf("{WORKFLOW_MODEL_CHECKER} = %q, want %q", got, "haiku")
@@ -1178,11 +1178,11 @@ func TestBuildWorkflowPlaceholderReplacements_SkipsOrchestrator(t *testing.T) {
 	var wf model.WorkflowManifest
 	wf.Metadata.Name = "myflow"
 	wf.Components.Roles = []model.WorkflowRole{
-		{Name: "myflow-orchestrator", Kind: "orchestrator", Model: "opus"},
-		{Name: "myflow-worker", Kind: "subagent", Model: "sonnet"},
+		{Name: "myflow-orchestrator", Kind: "orchestrator"},
+		{Name: "myflow-worker", Kind: "subagent", Models: map[string]string{"claude": "sonnet"}},
 	}
 
-	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", nil, nil)
+	result := renderers.BuildWorkflowPlaceholderReplacements(wf, "/ws", "skills", "claude", nil, nil)
 
 	if _, ok := result["{WORKFLOW_MODEL_ORCHESTRATOR}"]; ok {
 		t.Error("orchestrator role should not produce a placeholder")

--- a/internal/materialize/renderers/opencode.go
+++ b/internal/materialize/renderers/opencode.go
@@ -423,7 +423,7 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 	// to ensure {SDD_MODEL_*} markers are resolved from workflow role metadata.
 	// OpenCode subagent resolver: maps role names to their OpenCode agent names.
 	openCodeSubagentResolver := func(roleName string) string { return roleName }
-	replacements := buildWorkflowPlaceholderReplacements(wf, workspaceRoot, r.def.SkillDir, resolveOpenCodeModel, r.modelOverrides, openCodeSubagentResolver)
+	replacements := buildWorkflowPlaceholderReplacements(wf, workspaceRoot, r.def.SkillDir, "opencode", resolveOpenCodeModel, r.modelOverrides, openCodeSubagentResolver)
 	// Override {WORKFLOW_DIR} to point to the workspace-local workflow directory
 	// instead of the shared skillsBase path.
 	replacements["{WORKFLOW_DIR}"] = workflowDir
@@ -570,7 +570,7 @@ func (r *OpenCodeRenderer) buildSubagentEntry(role model.WorkflowRole, skillsBas
 		"tools":       toolsCopy(openCodeAgentTools),
 	}
 
-	// Check TUI-selected model override first, then fall back to role.Model from workflow.yaml.
+	// Check TUI-selected model override first, then fall back to role.Models["opencode"] from workflow.yaml.
 	modelValue := ""
 	if r.modelOverrides != nil {
 		if v, ok := r.modelOverrides[role.Name]; ok && v != "" && v != model.ModelInheritOption {
@@ -578,7 +578,7 @@ func (r *OpenCodeRenderer) buildSubagentEntry(role model.WorkflowRole, skillsBas
 		}
 	}
 	if modelValue == "" {
-		modelValue = role.Model
+		modelValue = role.ModelFor("opencode")
 	}
 	if modelValue != "" {
 		entry["model"] = resolveOpenCodeModel(modelValue)
@@ -629,9 +629,9 @@ func (r *OpenCodeRenderer) buildOrchestratorEntry(wf model.WorkflowManifest, rol
 	}
 
 	// Orchestrators generally do not specify a model (they inherit session model).
-	// Only set it if explicitly defined in role metadata.
-	if role.Model != "" {
-		entry["model"] = resolveOpenCodeModel(role.Model)
+	// Only set it if explicitly defined in role metadata for the opencode agent.
+	if m := role.ModelFor("opencode"); m != "" {
+		entry["model"] = resolveOpenCodeModel(m)
 	}
 
 	return entry, nil

--- a/internal/materialize/renderers/opencode_test.go
+++ b/internal/materialize/renderers/opencode_test.go
@@ -414,8 +414,8 @@ func sddParityManifest() model.WorkflowManifest {
 			Skills:     []string{"sdd-plan"},
 			Entrypoint: "ORCHESTRATOR.md",
 			Roles: []model.WorkflowRole{
-				{Name: "sdd-planner", Kind: "subagent", Skill: "sdd-plan", Model: "sonnet"},
-				{Name: "sdd-reviewer", Kind: "subagent", Skill: "sdd-plan", Model: "opus"},
+				{Name: "sdd-planner", Kind: "subagent", Skill: "sdd-plan", Models: map[string]string{"opencode": "sonnet"}},
+				{Name: "sdd-reviewer", Kind: "subagent", Skill: "sdd-plan", Models: map[string]string{"opencode": "opus"}},
 				{Name: "sdd-orchestrator", Kind: "orchestrator"},
 			},
 		},

--- a/internal/materialize/renderers/sdd_role_invariant_test.go
+++ b/internal/materialize/renderers/sdd_role_invariant_test.go
@@ -124,7 +124,7 @@ func sddTestWorkflowForRoleInvariant() model.WorkflowManifest {
 			Skills:     []string{"sdd-plan"},
 			Entrypoint: "ORCHESTRATOR.md",
 			Roles: []model.WorkflowRole{
-				{Name: "sdd-planner", Kind: "subagent", Skill: "sdd-plan", Model: "sonnet"},
+				{Name: "sdd-planner", Kind: "subagent", Skill: "sdd-plan", Models: map[string]string{"claude": "sonnet", "opencode": "sonnet", "copilot": "Claude Sonnet 4.6"}},
 				{Name: "sdd-orchestrator", Kind: "orchestrator"},
 			},
 		},

--- a/internal/model/workflow.go
+++ b/internal/model/workflow.go
@@ -66,8 +66,6 @@ func (m WorkflowMetadata) EffectiveWorkingDir() string {
 // WorkflowRole describes the projection metadata for a single agent role within a workflow.
 // Renderers use this to synthesize platform-native agent entries (e.g. opencode.json agents,
 // Copilot agent markdown) rather than hardcoding SDD-specific knowledge.
-//
-// Backward compatible: workflows without a roles list continue to parse and install normally.
 type WorkflowRole struct {
 	// Name is the agent role identifier, e.g. "sdd-explorer", "sdd-orchestrator".
 	Name string `yaml:"name"`
@@ -79,9 +77,19 @@ type WorkflowRole struct {
 	// For orchestrators this field is omitted; the entrypoint is used instead.
 	Skill string `yaml:"skill,omitempty"`
 
-	// Model is an optional short alias for the model used by this role (e.g. "sonnet", "opus").
-	// When omitted, renderers apply TUI-prompt or session-inheritance fallback rules.
-	Model string `yaml:"model,omitempty"`
+	// Models is a per-agent map of suggested model values for this role,
+	// keyed by agent name (claude, opencode, copilot). Required for subagent
+	// roles. Values are the alias or full model id understood by that agent's
+	// renderer:
+	//   - claude:   short tier names (haiku, sonnet, opus)
+	//   - opencode: short tier names (resolved to github-copilot/<full-id>)
+	//               or fully-qualified provider/model strings
+	//   - copilot:  VS Code display names verbatim (e.g. "Claude Sonnet 4.6")
+	// DevRune uses these as defaults in the TUI model selection step. Per-role
+	// TUI overrides win at render time; absent that, the value here is used.
+	// Orchestrator roles do not declare models — orchestrator selection is
+	// agent-specific and handled separately.
+	Models map[string]string `yaml:"models,omitempty"`
 
 	// Placeholder is an optional explicit placeholder key suffix override.
 	// When set, the placeholder {WORKFLOW_MODEL_<Placeholder>} is used instead of
@@ -89,6 +97,14 @@ type WorkflowRole struct {
 	// {WORKFLOW_MODEL_CHECKER}. When omitted, the key is derived by stripping the
 	// workflow name prefix from the role name.
 	Placeholder string `yaml:"placeholder,omitempty"`
+}
+
+// ModelFor returns the model declared for the given agent in this role, or "" if absent.
+func (r WorkflowRole) ModelFor(agent string) string {
+	if r.Models == nil {
+		return ""
+	}
+	return r.Models[agent]
 }
 
 // WorkflowComponents declares the components that make up the workflow.
@@ -203,8 +219,24 @@ func (w WorkflowManifest) Validate() error {
 		if role.Kind != "subagent" && role.Kind != "orchestrator" {
 			return fmt.Errorf("workflow %q: role %q kind must be \"subagent\" or \"orchestrator\" (got %q)", w.Metadata.Name, role.Name, role.Kind)
 		}
-		if role.Kind == "subagent" && role.Skill == "" {
-			return fmt.Errorf("workflow %q: subagent role %q should declare a skill", w.Metadata.Name, role.Name)
+		if role.Kind == "subagent" {
+			if role.Skill == "" {
+				return fmt.Errorf("workflow %q: subagent role %q must declare a skill", w.Metadata.Name, role.Name)
+			}
+			if len(role.Models) == 0 {
+				return fmt.Errorf("workflow %q: subagent role %q must declare a non-empty models map (one entry per agent: claude, opencode, copilot)", w.Metadata.Name, role.Name)
+			}
+			for agent, value := range role.Models {
+				if !ModelRoutingAgents[agent] {
+					return fmt.Errorf("workflow %q: role %q models key %q is not a recognised agent (expected one of: claude, opencode, copilot)", w.Metadata.Name, role.Name, agent)
+				}
+				if value == "" {
+					return fmt.Errorf("workflow %q: role %q models[%q] must not be empty", w.Metadata.Name, role.Name, agent)
+				}
+			}
+		}
+		if role.Kind == "orchestrator" && len(role.Models) > 0 {
+			return fmt.Errorf("workflow %q: orchestrator role %q must not declare models — orchestrator model selection is agent-specific and handled separately", w.Metadata.Name, role.Name)
 		}
 	}
 	if w.Components.Hooks != nil {

--- a/internal/model/workflow_roles.go
+++ b/internal/model/workflow_roles.go
@@ -84,6 +84,7 @@ var copilotModelEntries = []CopilotModelEntry{
 	{DisplayName: "Gemini 3 Flash (Preview)", Provider: "Google", Availability: "Pro and above", Tier: 2.0, Multiplier: 0.33},
 	// OpenAI
 	{DisplayName: "GPT-5 mini", Provider: "OpenAI", Availability: "Free · All plans", Tier: 1.0, Multiplier: 0.0},
+	{DisplayName: "GPT-5.5", Provider: "OpenAI", Availability: "Pro and above", Tier: 2.0, Multiplier: 1.0},
 	{DisplayName: "GPT-5.4", Provider: "OpenAI", Availability: "Pro and above", Tier: 2.0, Multiplier: 1.0},
 	{DisplayName: "GPT-5.3-Codex", Provider: "OpenAI", Availability: "Pro and above", Tier: 2.0, Multiplier: 1.0},
 	// xAI

--- a/internal/model/workflow_roles_test.go
+++ b/internal/model/workflow_roles_test.go
@@ -80,10 +80,10 @@ func TestBackwardCompatAliases(t *testing.T) {
 func TestCopilotModelOptions(t *testing.T) {
 	opts := CopilotModelOptions()
 
-	// Must return exactly 12 options: sentinel + 11 models (Opus 4.6 added in v2.11.x).
-	const wantTotal = 12
+	// Must return exactly 13 options: sentinel + 12 models.
+	const wantTotal = 13
 	if len(opts) != wantTotal {
-		t.Fatalf("CopilotModelOptions() returned %d options, want %d (1 sentinel + 11 models)", len(opts), wantTotal)
+		t.Fatalf("CopilotModelOptions() returned %d options, want %d (1 sentinel + 12 models)", len(opts), wantTotal)
 	}
 
 	// First option must be the inherit sentinel.
@@ -96,7 +96,8 @@ func TestCopilotModelOptions(t *testing.T) {
 
 	// Expected display-name order: Anthropic haiku → sonnet → opus-4.7 → opus-4.6
 	// (newest Opus first), then Google → OpenAI → xAI.
-	// Values are VS Code display names, NOT API slugs.
+	// Within OpenAI: mini first, then versioned standards newest-first (5.5 before 5.4),
+	// then Codex variants. Values are VS Code display names, NOT API slugs.
 	wantValues := []string{
 		"Claude Haiku 4.5",         // Anthropic, pos 1
 		"Claude Sonnet 4.6",        // Anthropic, pos 2
@@ -106,9 +107,10 @@ func TestCopilotModelOptions(t *testing.T) {
 		"Gemini 3.1 Pro (Preview)", // Google,    pos 6
 		"Gemini 3 Flash (Preview)", // Google,    pos 7
 		"GPT-5 mini",               // OpenAI,    pos 8
-		"GPT-5.4",                  // OpenAI,    pos 9
-		"GPT-5.3-Codex",            // OpenAI,    pos 10
-		"Grok Code Fast 1",         // xAI,       pos 11
+		"GPT-5.5",                  // OpenAI,    pos 9
+		"GPT-5.4",                  // OpenAI,    pos 10
+		"GPT-5.3-Codex",            // OpenAI,    pos 11
+		"Grok Code Fast 1",         // xAI,       pos 12
 	}
 	for i, want := range wantValues {
 		got := opts[i+1]
@@ -139,9 +141,10 @@ func TestCopilotModelOptions(t *testing.T) {
 		{6, "Gemini 3.1 Pro (Preview)", "Google"},
 		{7, "Gemini 3 Flash (Preview)", "Google"},
 		{8, "GPT-5 mini", "OpenAI"},
-		{9, "GPT-5.4", "OpenAI"},
-		{10, "GPT-5.3-Codex", "OpenAI"},
-		{11, "Grok Code Fast 1", "xAI"},
+		{9, "GPT-5.5", "OpenAI"},
+		{10, "GPT-5.4", "OpenAI"},
+		{11, "GPT-5.3-Codex", "OpenAI"},
+		{12, "Grok Code Fast 1", "xAI"},
 	}
 	for _, c := range providerChecks {
 		label := opts[c.idx].Label
@@ -181,7 +184,7 @@ func TestCopilotModelOptions(t *testing.T) {
 		{3, "claude-opus-4.7", "7.5×"},
 		{4, "claude-opus-4.6", "3×"},
 		{8, "gpt-5-mini", "0×"},
-		{11, "grok-code-fast-1", "0.25×"},
+		{12, "grok-code-fast-1", "0.25×"},
 	}
 	for _, c := range multiplierChecks {
 		label := opts[c.idx].Label
@@ -203,14 +206,14 @@ func TestCopilotModelOptions(t *testing.T) {
 			t.Errorf("Google position %d: got %q, want %q", i+5, opts[i+5].Value, want)
 		}
 	}
-	openaiIDs := []string{"GPT-5 mini", "GPT-5.4", "GPT-5.3-Codex"}
+	openaiIDs := []string{"GPT-5 mini", "GPT-5.5", "GPT-5.4", "GPT-5.3-Codex"}
 	for i, want := range openaiIDs {
 		if opts[i+8].Value != want {
 			t.Errorf("OpenAI position %d: got %q, want %q", i+8, opts[i+8].Value, want)
 		}
 	}
-	if opts[11].Value != "Grok Code Fast 1" {
-		t.Errorf("xAI position 11: got %q, want %q", opts[11].Value, "Grok Code Fast 1")
+	if opts[12].Value != "Grok Code Fast 1" {
+		t.Errorf("xAI position 12: got %q, want %q", opts[12].Value, "Grok Code Fast 1")
 	}
 }
 
@@ -252,11 +255,11 @@ func TestModelRoutingAgents_IncludesCopilot(t *testing.T) {
 
 // TestCopilotModelOptionsUpTo verifies tier-based filtering of Copilot model options.
 func TestCopilotModelOptionsUpTo(t *testing.T) {
-	// MaxFloat64 → same result as CopilotModelOptions() — sentinel + all 11 models.
+	// MaxFloat64 → same result as CopilotModelOptions() — sentinel + all 12 models.
 	optsAll := CopilotModelOptionsUpTo(math.MaxFloat64)
-	const wantTotal = 12
+	const wantTotal = 13
 	if len(optsAll) != wantTotal {
-		t.Errorf("CopilotModelOptionsUpTo(MaxFloat64) returned %d options, want %d (sentinel + 11 models)", len(optsAll), wantTotal)
+		t.Errorf("CopilotModelOptionsUpTo(MaxFloat64) returned %d options, want %d (sentinel + 12 models)", len(optsAll), wantTotal)
 	}
 	if optsAll[0].Value != ModelInheritOption {
 		t.Errorf("CopilotModelOptionsUpTo(MaxFloat64): first option = %q, want sentinel %q", optsAll[0].Value, ModelInheritOption)
@@ -278,10 +281,10 @@ func TestCopilotModelOptionsUpTo(t *testing.T) {
 		}
 	}
 
-	// Tier 2.0 → sentinel + all except both Opus (tier 3.0) = 10 options.
+	// Tier 2.0 → sentinel + all except both Opus (tier 3.0) = 11 options.
 	opts2 := CopilotModelOptionsUpTo(2.0)
-	if len(opts2) != 10 {
-		t.Errorf("CopilotModelOptionsUpTo(2.0) returned %d options, want 10 (sentinel + 9 tier-1/2 models)", len(opts2))
+	if len(opts2) != 11 {
+		t.Errorf("CopilotModelOptionsUpTo(2.0) returned %d options, want 11 (sentinel + 10 tier-1/2 models)", len(opts2))
 	}
 	if opts2[0].Value != ModelInheritOption {
 		t.Errorf("CopilotModelOptionsUpTo(2.0): first option = %q, want sentinel %q", opts2[0].Value, ModelInheritOption)
@@ -296,10 +299,10 @@ func TestCopilotModelOptionsUpTo(t *testing.T) {
 		}
 	}
 
-	// Tier 3.0 → sentinel + all 11 models = 12 options (same as MaxFloat64).
+	// Tier 3.0 → sentinel + all 12 models = 13 options (same as MaxFloat64).
 	opts3 := CopilotModelOptionsUpTo(3.0)
 	if len(opts3) != wantTotal {
-		t.Errorf("CopilotModelOptionsUpTo(3.0) returned %d options, want %d (sentinel + 11 models)", len(opts3), wantTotal)
+		t.Errorf("CopilotModelOptionsUpTo(3.0) returned %d options, want %d (sentinel + 12 models)", len(opts3), wantTotal)
 	}
 	if opts3[0].Value != ModelInheritOption {
 		t.Errorf("CopilotModelOptionsUpTo(3.0): first option = %q, want sentinel %q", opts3[0].Value, ModelInheritOption)

--- a/internal/model/workflow_test.go
+++ b/internal/model/workflow_test.go
@@ -174,6 +174,90 @@ func TestWorkflowManifest_Validate(t *testing.T) {
 	}
 }
 
+// TestWorkflowRole_ValidateModelsRequired verifies that subagent roles must declare
+// a non-empty models map keyed by recognised agent names, and orchestrator roles
+// must NOT declare models.
+func TestWorkflowRole_ValidateModelsRequired(t *testing.T) {
+	cases := []struct {
+		name    string
+		role    WorkflowRole
+		wantErr string
+	}{
+		{
+			name:    "subagent with valid models map passes",
+			role:    WorkflowRole{Name: "r", Kind: "subagent", Skill: "s", Models: map[string]string{"claude": "haiku"}},
+			wantErr: "",
+		},
+		{
+			name:    "subagent without models fails",
+			role:    WorkflowRole{Name: "r", Kind: "subagent", Skill: "s"},
+			wantErr: "must declare a non-empty models map",
+		},
+		{
+			name:    "subagent with unknown agent key fails",
+			role:    WorkflowRole{Name: "r", Kind: "subagent", Skill: "s", Models: map[string]string{"vscode": "x"}},
+			wantErr: "is not a recognised agent",
+		},
+		{
+			name:    "subagent with empty model value fails",
+			role:    WorkflowRole{Name: "r", Kind: "subagent", Skill: "s", Models: map[string]string{"claude": ""}},
+			wantErr: "must not be empty",
+		},
+		{
+			name:    "orchestrator without models passes",
+			role:    WorkflowRole{Name: "r", Kind: "orchestrator"},
+			wantErr: "",
+		},
+		{
+			name:    "orchestrator with models is rejected",
+			role:    WorkflowRole{Name: "r", Kind: "orchestrator", Models: map[string]string{"claude": "opus"}},
+			wantErr: "orchestrator role",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			wf := WorkflowManifest{
+				APIVersion: "devrune/workflow/v1",
+				Metadata:   WorkflowMetadata{Name: "wf", Version: "1.0.0"},
+				Components: WorkflowComponents{
+					Skills: []string{"s"},
+					Roles:  []WorkflowRole{c.role},
+				},
+			}
+			err := wf.Validate()
+			if c.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", c.wantErr)
+			}
+			if !containsString(err.Error(), c.wantErr) {
+				t.Errorf("Validate() = %q, want error containing %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestWorkflowRole_ModelFor verifies the ModelFor accessor.
+func TestWorkflowRole_ModelFor(t *testing.T) {
+	r := WorkflowRole{Models: map[string]string{"claude": "haiku", "opencode": "sonnet"}}
+	if got := r.ModelFor("claude"); got != "haiku" {
+		t.Errorf("ModelFor(claude) = %q, want haiku", got)
+	}
+	if got := r.ModelFor("copilot"); got != "" {
+		t.Errorf("ModelFor(copilot) = %q, want empty", got)
+	}
+
+	empty := WorkflowRole{}
+	if got := empty.ModelFor("claude"); got != "" {
+		t.Errorf("ModelFor on nil Models = %q, want empty", got)
+	}
+}
+
 // TestWorkflowManifest_Validate_WithNewOptionalFields verifies that Validate() still
 // passes when new optional fields (DecisionRules, InvocationControls, Registry,
 // Permissions) are empty, and passes when they are populated.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -122,10 +122,18 @@ func Run(projectDir string, catalogSources []string, existing *ExistingConfig) (
 		} else if savedManifest := loadExistingManifest(); savedManifest != nil {
 			savedModels = mergeWorkflowModels(savedManifest.Workflows)
 		}
-		// SDD workflow is always auto-selected — pass sddAutoSelected=true
-		// so model selection does not skip when no scan results exist yet.
-		var emptyManifests []model.WorkflowManifest
-		wm, err := steps.RunWorkflowModelSelection(agents, steps.SelectionResult{}, savedModels, emptyManifests, true, 3)
+		// SDD workflow is always auto-selected. Fetch its workflow.yaml from
+		// the canonical catalog source up-front so the model-selection step
+		// can seed per-agent role defaults from the live yaml. Cache makes the
+		// fetch near-instant on subsequent runs; on the first run this is the
+		// same data the regular scan step would download a few moments later.
+		// If the fetch fails (no network, proxy issues, …) the wizard
+		// continues — the model selection step simply shows "inherit" defaults.
+		var seedManifests []model.WorkflowManifest
+		if wf, err := FetchSDDWorkflow(context.Background(), cachePath()); err == nil {
+			seedManifests = append(seedManifests, wf)
+		}
+		wm, err := steps.RunWorkflowModelSelection(agents, steps.SelectionResult{}, savedModels, seedManifests, true, 3)
 		if err != nil {
 			return RunResult{}, mapErr(err)
 		}

--- a/internal/tui/scanner.go
+++ b/internal/tui/scanner.go
@@ -31,6 +31,59 @@ type ScannedRepo struct {
 	Error     error             // scan error (nil if ok)
 }
 
+// CanonicalSDDSource is the source ref string for the catalog that ships SDD.
+// SDD is auto-selected by the wizard; this constant lets DevRune fetch its
+// workflow.yaml at startup so the model-selection step can seed per-agent
+// defaults from the catalog before the user enters any other repo source.
+const CanonicalSDDSource = "github:davidarce/devrune-starter-catalog"
+
+// FetchSDDWorkflow fetches the SDD workflow manifest from the canonical
+// devrune-starter-catalog source via the shared cache layer.
+//
+// On a cold cache this performs an HTTP fetch; on a warm cache it loads from
+// disk. The returned manifest seeds per-agent role defaults in the TUI
+// model-selection step. The same source is fetched again by ScanRepositories
+// at the regular scan step (cache makes the second call near-instant).
+//
+// Returns (zero-value, nil) when no manifest can be obtained — the wizard
+// continues, the model-selection step simply falls back to "inherit" defaults.
+// A non-nil error is reserved for unrecoverable conditions (the caller may
+// still ignore it and proceed).
+func FetchSDDWorkflow(ctx context.Context, cachePath string) (model.WorkflowManifest, error) {
+	cacheStore := cache.NewFileCacheStore(cachePath)
+	githubFetcher := cache.NewGitHubFetcher("")
+	gitlabFetcher := cache.NewGitLabFetcher("")
+	localFetcher := cache.NewLocalFetcher()
+	multiFetcher := cache.NewMultiFetcher(githubFetcher, gitlabFetcher, localFetcher)
+
+	sourceRef, err := model.ParseSourceRef(CanonicalSDDSource, ".")
+	if err != nil {
+		return model.WorkflowManifest{}, fmt.Errorf("parse SDD source: %w", err)
+	}
+	data, err := multiFetcher.Fetch(ctx, sourceRef)
+	if err != nil {
+		return model.WorkflowManifest{}, fmt.Errorf("fetch SDD source: %w", err)
+	}
+	dir, err := cacheStore.Store(sourceRef.CacheKey(), data)
+	if err != nil {
+		return model.WorkflowManifest{}, fmt.Errorf("cache SDD source: %w", err)
+	}
+
+	wfPath := filepath.Join(dir, "workflows", "sdd", "workflow.yaml")
+	raw, err := os.ReadFile(wfPath)
+	if err != nil {
+		return model.WorkflowManifest{}, fmt.Errorf("read SDD workflow.yaml: %w", err)
+	}
+	var wf model.WorkflowManifest
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		return model.WorkflowManifest{}, fmt.Errorf("parse SDD workflow.yaml: %w", err)
+	}
+	if err := wf.Validate(); err != nil {
+		return model.WorkflowManifest{}, fmt.Errorf("invalid SDD workflow.yaml: %w", err)
+	}
+	return wf, nil
+}
+
 // ScanRepositories fetches and enumerates content from each source ref.
 // It creates a shared cache at cachePath and returns one ScannedRepo per source.
 // Errors from individual repos are recorded in ScannedRepo.Error and do not

--- a/internal/tui/steps/workflow_models.go
+++ b/internal/tui/steps/workflow_models.go
@@ -169,12 +169,14 @@ func WorkflowModelLayout(numRoles, termHeight int) huh.Layout {
 	return huh.LayoutColumns(cols)
 }
 
-// subagentRoles returns the subagent roles that have a Model field from a workflow.
+// subagentRoles returns the subagent roles that declare per-agent model defaults
+// from the given workflow manifests. Roles without a Models map are skipped — they
+// would render no default in the TUI and aren't actionable for model selection.
 func subagentRoles(wfs []model.WorkflowManifest) []model.WorkflowRole {
 	var roles []model.WorkflowRole
 	for _, wf := range wfs {
 		for _, role := range wf.Components.Roles {
-			if role.Kind == "subagent" && role.Model != "" {
+			if role.Kind == "subagent" && len(role.Models) > 0 {
 				roles = append(roles, role)
 			}
 		}
@@ -286,20 +288,30 @@ func newModelSelectorModel(
 					opts = filterCopilotOptions(agent.ModelOptions, orchestratorTier)
 				}
 				defaultIdx := 0 // inherit sentinel
+				// Selection precedence: user's saved choice > workflow.yaml's
+				// per-agent default > inherit. Per-agent yaml defaults come from
+				// role.Models[agent] and seed the form on first install.
+				seed := ""
 				if savedModels != nil {
 					if agentMap, ok := savedModels[agent.Name]; ok {
-						if saved, ok := agentMap[role.Name]; ok && saved != "" {
-							// Build-time reset: if saved phase value's tier exceeds
-							// orchestratorTier, treat as sentinel (index 0).
-							if agent.Name == "copilot" && model.CopilotTierForModel(saved) > orchestratorTier {
-								// Reset to sentinel — do not restore the out-of-range saved value.
-							} else {
-								for i, opt := range opts {
-									if opt.Value == saved {
-										defaultIdx = i
-										break
-									}
-								}
+						if saved, ok := agentMap[role.Name]; ok {
+							seed = saved
+						}
+					}
+				}
+				if seed == "" {
+					seed = role.ModelFor(agent.Name)
+				}
+				if seed != "" {
+					// Build-time reset: if seed value's tier exceeds orchestratorTier
+					// (Copilot only), treat as sentinel (index 0).
+					if agent.Name == "copilot" && model.CopilotTierForModel(seed) > orchestratorTier {
+						// Reset to sentinel — do not restore the out-of-range value.
+					} else {
+						for i, opt := range opts {
+							if opt.Value == seed {
+								defaultIdx = i
+								break
 							}
 						}
 					}
@@ -901,25 +913,14 @@ func RunWorkflowModelSelection(
 		return nil, nil
 	}
 
-	// Get subagent roles that define a model.
+	// Get subagent roles that declare per-agent defaults.
 	roles := subagentRoles(workflows)
-	// Fresh install with SDD auto-selected but no workflow manifests loaded yet
-	// (model selection runs before the scan step): synthesize the canonical SDD
-	// subagent role list so the form always shows on first install.
-	if len(roles) == 0 && sddAutoSelected && len(savedModels) == 0 {
-		for _, roleName := range []string{"sdd-explorer", "sdd-planner", "sdd-implementer", "sdd-reviewer", "sdd-advisor"} {
-			roles = append(roles, model.WorkflowRole{
-				Name:  roleName,
-				Kind:  "subagent",
-				Model: roleName,
-			})
-		}
-	}
-	// When no roles are found from workflow manifests but savedModels has entries,
-	// synthesize roles from the saved model keys so the form always shows and
-	// lets the user review or change their previous selections.
+	// Defensive fallback: when workflow manifests are absent (e.g. "manage sdd
+	// models" CLI before any scan) but the user has saved model selections from
+	// a previous run, synthesize roles from those keys so the form still loads.
+	// These synthesized roles carry no Models map — the TUI default seed simply
+	// uses the saved selections.
 	if len(roles) == 0 && len(savedModels) > 0 {
-		// Collect unique role names from all agents' saved models.
 		seen := make(map[string]bool)
 		var roleNames []string
 		for _, roleMap := range savedModels {
@@ -937,9 +938,8 @@ func RunWorkflowModelSelection(
 		})
 		for _, roleName := range roleNames {
 			roles = append(roles, model.WorkflowRole{
-				Name:  roleName,
-				Kind:  "subagent",
-				Model: roleName,
+				Name: roleName,
+				Kind: "subagent",
 			})
 		}
 	}

--- a/internal/tui/steps/workflow_models_test.go
+++ b/internal/tui/steps/workflow_models_test.go
@@ -121,7 +121,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoRepos(t *testing.T) {
 	}
 }
 
-func TestRunWorkflowModelSelection_ReturnsNilWhenNoRolesHaveModel(t *testing.T) {
+func TestRunWorkflowModelSelection_ReturnsNilWhenNoRolesHaveModels(t *testing.T) {
 	agents := []string{"claude"}
 	selection := SelectionResult{
 		Repos: []RepoSelectionResult{
@@ -131,7 +131,7 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoRolesHaveModel(t *testing.T) 
 			},
 		},
 	}
-	// Workflow with roles but no model fields.
+	// Workflow whose only role is an orchestrator (no models map by design).
 	workflows := []model.WorkflowManifest{
 		{
 			Metadata: model.WorkflowMetadata{Name: "sdd"},
@@ -148,7 +148,29 @@ func TestRunWorkflowModelSelection_ReturnsNilWhenNoRolesHaveModel(t *testing.T) 
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result != nil {
-		t.Errorf("expected nil result when no roles have model, got %v", result)
+		t.Errorf("expected nil result when no roles declare models, got %v", result)
+	}
+}
+
+func TestSubagentRoles_FiltersByModelsMap(t *testing.T) {
+	wfs := []model.WorkflowManifest{
+		{
+			Metadata: model.WorkflowMetadata{Name: "sdd"},
+			Components: model.WorkflowComponents{
+				Roles: []model.WorkflowRole{
+					{Name: "sdd-orchestrator", Kind: "orchestrator"},
+					{Name: "sdd-explorer", Kind: "subagent", Skill: "sdd-explore", Models: map[string]string{"claude": "haiku"}},
+					{Name: "no-models-role", Kind: "subagent", Skill: "x"}, // skipped: no Models map
+				},
+			},
+		},
+	}
+	roles := subagentRoles(wfs)
+	if len(roles) != 1 || roles[0].Name != "sdd-explorer" {
+		t.Fatalf("subagentRoles = %+v, want only sdd-explorer", roles)
+	}
+	if got := roles[0].ModelFor("claude"); got != "haiku" {
+		t.Errorf("ModelFor(claude) = %q, want %q", got, "haiku")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `WorkflowRole.Model` (single string) is replaced by `WorkflowRole.Models map[string]string` keyed by agent name (claude/opencode/copilot). Required for `kind: subagent`; rejected on `kind: orchestrator`.
- DevRune fetches SDD's `workflow.yaml` from the canonical catalog source (`github:davidarce/devrune-starter-catalog`) at wizard start via the existing cache layer, before the model-selection step. The synthetic hardcoded SDD role list is gone.
- Each renderer (claude / opencode / copilot) reads `role.Models[agent]` instead of `role.Model`. `buildWorkflowPlaceholderReplacements` gains an `agentName` parameter.

## Why

The TUI model-selection step on a fresh install never received the yaml's declared model defaults. `app.go` passed an empty `[]WorkflowManifest` to `RunWorkflowModelSelection` (model selection runs before the catalog scan by design), so the synthetic fallback in `workflow_models.go:909-917` used `Model: roleName` placeholders instead of real values. Even when the user later saved choices to `devrune.yaml`, the catalog could only express one tier per role across all agents — not enough for "haiku on claude, claude-haiku-4.5 on opencode, Claude Haiku 4.5 on copilot".

## Schema

```yaml
roles:
  - name: sdd-explorer
    kind: subagent
    skill: sdd-explore
    models:
      claude: haiku
      opencode: haiku
      copilot: Claude Haiku 4.5
```

## Architecture

`internal/tui/scanner.go` exposes `FetchSDDWorkflow(ctx, cachePath)` and the constant `CanonicalSDDSource`. `app.go:115-133` calls it before invoking `RunWorkflowModelSelection`, passing the resulting manifest. The same fetch is performed again at the regular scan step but the cache layer makes it near-instant. Network failures fall through silently — the wizard continues with "inherit" defaults.

## Breaking change

Catalogs that still declare `model:` instead of `models:` will fail `Validate()`. Requires the matching catalog update in [`davidarce/devrune-starter-catalog#53`](https://github.com/davidarce/devrune-starter-catalog/issues/53).

## Test plan

- [x] `go test ./...` (full suite)
- [x] Unit tests added: `TestSubagentRoles_FiltersByModelsMap`, `TestWorkflowRole_ValidateModelsRequired`, `TestWorkflowRole_ModelFor`
- [ ] Manual: install SDD from scratch, verify model-selection step seeds per-agent defaults from the catalog
- [ ] Manual: re-run "manage sdd models" and verify saved selections still load
- [ ] Manual: install offline (no cache, no network) — wizard continues with "inherit" defaults

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)