### PR TITLE
fix(materialize/renderers): stop consuming REGISTRY for OpenCode/Copilot installs

### DIFF
--- a/internal/materialize/renderers/copilot.go
+++ b/internal/materialize/renderers/copilot.go
@@ -474,20 +474,15 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 			if variantOrchPath != "" {
 				effectiveSrc = variantOrchPath // use variant if found
 			}
-			// Resolve the Copilot registry variant (or generic fallback) so the
-			// orchestrator agent file embeds both ambient rules + playbook —
-			// Copilot custom agents have no shared catalog context.
-			registryPath := ""
-			if wf.Components.Registry != "" {
-				variantName := strings.TrimSuffix(wf.Components.Registry, ".md") + ".copilot.md"
-				if _, statErr := os.Stat(filepath.Join(cachePath, variantName)); statErr == nil {
-					registryPath = filepath.Join(cachePath, variantName)
-				} else if _, statErr := os.Stat(filepath.Join(cachePath, wf.Components.Registry)); statErr == nil {
-					registryPath = filepath.Join(cachePath, wf.Components.Registry)
-				}
-			}
+			// REGISTRY blocks are intentionally NOT consumed for Copilot installs.
+			// Copilot has a primary `.agent.md` the user explicitly invokes; the
+			// playbook lives there (rendered from ORCHESTRATOR.copilot.md alone).
+			// Injecting REGISTRY content into the orchestrator body would duplicate
+			// or contradict the playbook. REGISTRY.copilot.md in the catalog is kept
+			// as an empty stub to prevent the variant resolver from falling back to
+			// the generic Claude-flavoured REGISTRY.md.
 			dstPath := filepath.Join(agentsBase, orchRoleName+".agent.md")
-			if err := r.installOrchestratorAgent(effectiveSrc, registryPath, dstPath, wf, replacements); err != nil {
+			if err := r.installOrchestratorAgent(effectiveSrc, "", dstPath, wf, replacements); err != nil {
 				return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: workflow orchestrator: %w", err)
 			}
 			managedPaths = append(managedPaths, dstPath)
@@ -603,16 +598,13 @@ func (r *CopilotRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath s
 		}
 	}
 
-	// Capture registry content for catalog injection; apply shared placeholder replacements.
-	if wf.Components.Registry != "" {
-		content, err := captureRegistryContent(cachePath, wf.Components.Registry, replacements)
-		if err != nil {
-			return matypes.WorkflowInstallResult{}, fmt.Errorf("copilot: capture registry: %w", err)
-		}
-		if content != "" {
-			r.registryContents[wf.Metadata.Name] = content
-		}
-	}
+	// REGISTRY blocks are intentionally NOT captured for Copilot installs.
+	// Copilot has a primary `.agent.md` for the orchestrator (synthesized
+	// above); injecting the playbook into an ambient catalog would leak
+	// workflow-specific rules into non-workflow sessions and duplicate the
+	// orchestrator agent's body. r.registryContents stays empty for this
+	// workflow so RenderRootCatalog produces no SDD section in the ambient
+	// instructions file.
 
 	// Resolve placeholders in all installed .md files under skillsBase and agentsBase.
 	// agentsBase now contains the orchestrator .agent.md and the _shared/ directory.

--- a/internal/materialize/renderers/copilot_test.go
+++ b/internal/materialize/renderers/copilot_test.go
@@ -490,11 +490,14 @@ func TestCopilotRenderer_InstallWorkflow_OrchestratorOnlyInAgentsDir(t *testing.
 	}
 }
 
-// TestCopilotRenderer_InstallWorkflow_RegistryInjectedIntoCatalog verifies that
-// registry content is captured (for potential other use) but NOT injected verbatim
-// into the catalog — instead a minimal orchestrator pointer is emitted.
-// Also verifies no REGISTRY.md file is written anywhere in the workspace.
-func TestCopilotRenderer_InstallWorkflow_RegistryInjectedIntoCatalog(t *testing.T) {
+// TestCopilotRenderer_InstallWorkflow_RegistryNotCaptured verifies that
+// registry content is NOT captured into the renderer's registryContents
+// map for Copilot installs and is NOT copied loose anywhere in the
+// workspace. Copilot has a primary `.agent.md` for the orchestrator
+// (synthesized from ORCHESTRATOR.copilot.md); leaking REGISTRY content
+// into the ambient instructions file would inject workflow-specific
+// rules into non-workflow sessions.
+func TestCopilotRenderer_InstallWorkflow_RegistryNotCaptured(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	def := copilotParityDef(workspaceRoot)
 	r := renderers.NewCopilotRenderer(def)
@@ -529,18 +532,12 @@ func TestCopilotRenderer_InstallWorkflow_RegistryInjectedIntoCatalog(t *testing.
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
-	// Verify registry content is captured (for later use by RenderRootCatalog).
+	// REGISTRY content must NOT be captured for Copilot — primary `.agent.md`
+	// owns the playbook; the ambient catalog should not carry workflow-specific
+	// orchestrator rules.
 	contents := r.RegistryContents()
-	// Registry content is captured but not verbatim-injected (Copilot emits minimal pointer).
-	// The workflow name "sdd" must exist as a key.
-	if _, ok := contents[wf.Metadata.Name]; !ok {
-		t.Errorf("RegistryContents should contain captured content for workflow 'sdd'; got keys: %v", func() []string {
-			var keys []string
-			for k := range contents {
-				keys = append(keys, k)
-			}
-			return keys
-		}())
+	if _, ok := contents[wf.Metadata.Name]; ok {
+		t.Errorf("RegistryContents must NOT contain workflow %q for Copilot installs; got captured content", wf.Metadata.Name)
 	}
 
 	// No loose REGISTRY.md should exist anywhere in workspace.

--- a/internal/materialize/renderers/opencode.go
+++ b/internal/materialize/renderers/opencode.go
@@ -428,16 +428,22 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 	// instead of the shared skillsBase path.
 	replacements["{WORKFLOW_DIR}"] = workflowDir
 
-	// Capture registry content for catalog injection; apply shared replacements.
-	if wf.Components.Registry != "" {
-		content, err := captureRegistryContent(cachePath, wf.Components.Registry, replacements)
-		if err != nil {
-			return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: capture registry: %w", err)
-		}
-		if content != "" {
-			r.registryContents[wf.Metadata.Name] = content
-		}
-	}
+	// REGISTRY blocks are intentionally NOT consumed for OpenCode installs.
+	//
+	// Why: the REGISTRY pattern injects ambient orchestrator context into
+	// CLAUDE.md / AGENTS.md catalogs because Claude/Factory have no "primary
+	// agent" concept — the main session needs the playbook to know when to
+	// engage the workflow. OpenCode has a primary agent the user explicitly
+	// selects (synthesized from components.roles below); the playbook lives
+	// in that agent's prompt (rendered from ORCHESTRATOR.opencode.md alone).
+	// Injecting REGISTRY content into either AGENTS.md or the orchestrator
+	// prompt would (a) leak workflow-specific rules into non-workflow sessions
+	// and (b) duplicate / contradict the orchestrator prompt itself.
+	//
+	// We deliberately skip both the catalog capture (r.registryContents) and
+	// the prompt prepend (registryPath) here. REGISTRY.{opencode,copilot}.md
+	// in the catalog are kept as empty stubs to prevent the variant resolver
+	// from falling back to the generic Claude-flavoured REGISTRY.md.
 
 	// Resolve placeholders in skill .md files under skillsBase.
 	if err := resolvePlaceholders(skillsBase, replacements); err != nil {
@@ -450,23 +456,10 @@ func (r *OpenCodeRenderer) InstallWorkflow(wf model.WorkflowManifest, cachePath 
 		}
 	}
 
-	// Resolve registry variant for the orchestrator prompt (registry +
-	// playbook combined). The OpenCode primary agent has no separate ambient
-	// catalog, so the registry block is prepended to the orchestrator prompt
-	// to govern its behaviour.
-	registryPath := ""
-	if wf.Components.Registry != "" {
-		variantName := strings.TrimSuffix(wf.Components.Registry, ".md") + ".opencode.md"
-		if _, statErr := os.Stat(filepath.Join(cachePath, variantName)); statErr == nil {
-			registryPath = filepath.Join(cachePath, variantName)
-		} else if _, statErr := os.Stat(filepath.Join(cachePath, wf.Components.Registry)); statErr == nil {
-			registryPath = filepath.Join(cachePath, wf.Components.Registry)
-		}
-	}
-
 	// Synthesize SDD agents into opencode.json from components.roles.
+	// registryPath is empty by design (see REGISTRY-skip rationale above).
 	if len(wf.Components.Roles) > 0 {
-		if err := r.synthesizeAgents(wf, orchPath, registryPath, workspaceRoot, skillsBase, replacements); err != nil {
+		if err := r.synthesizeAgents(wf, orchPath, "", workspaceRoot, skillsBase, replacements); err != nil {
 			return matypes.WorkflowInstallResult{}, fmt.Errorf("opencode: synthesize agents: %w", err)
 		}
 		managedPaths = append(managedPaths, filepath.Join(workspaceRoot, "opencode.json"))
@@ -590,14 +583,14 @@ func (r *OpenCodeRenderer) buildSubagentEntry(role model.WorkflowRole, skillsBas
 // buildOrchestratorEntry creates an opencode.json agent entry for the orchestrator role.
 // The prompt is the full content of the ORCHESTRATOR.md file with all placeholders
 // resolved ({SKILLS_PATH}, {SDD_MODEL_*}) using the provided replacements map.
+//
+// registryPath is accepted for signature compatibility but should be empty for
+// OpenCode installs — REGISTRY blocks are not concatenated into the orchestrator
+// prompt (see RenderWorkflow). If a non-empty path is supplied, it is read and
+// prepended for backward compatibility, but the canonical caller passes "".
 func (r *OpenCodeRenderer) buildOrchestratorEntry(wf model.WorkflowManifest, role model.WorkflowRole, orchPath, registryPath string, replacements map[string]string) (map[string]any, error) {
 	var prompt string
 
-	// Prepend the registry block (ambient rules: Role Invariant, Evaluation
-	// Gate, Memory Protocols, Engram Availability Guard, Session close) so the
-	// orchestrator agent has the same governing rules a CLAUDE.md ambient
-	// install would provide for the main session. OpenCode primary agents have
-	// no shared catalog context, so embedding here is the only delivery path.
 	if registryPath != "" {
 		regData, err := os.ReadFile(registryPath)
 		if err != nil {

--- a/internal/materialize/renderers/opencode_test.go
+++ b/internal/materialize/renderers/opencode_test.go
@@ -641,11 +641,13 @@ func TestOpenCodeRenderer_InstallWorkflow_NoAgentsDirCreated(t *testing.T) {
 	}
 }
 
-// TestOpenCodeRenderer_InstallWorkflow_RegistryInjectedIntoCatalog verifies that
-// a workflow Registry file is NOT copied loose. After the post-review fix, registry
-// content is also NOT injected verbatim into the catalog — a minimal orchestrator
-// pointer is emitted instead.
-func TestOpenCodeRenderer_InstallWorkflow_RegistryInjectedIntoCatalog(t *testing.T) {
+// TestOpenCodeRenderer_InstallWorkflow_RegistryNotCaptured verifies that
+// a workflow Registry file is NOT copied loose AND NOT captured into the
+// renderer's registryContents map for OpenCode installs. OpenCode primary
+// agents own their playbook in opencode.json — leaking the REGISTRY block
+// into AGENTS.md would inject workflow-specific rules into non-workflow
+// sessions and duplicate the orchestrator agent's prompt.
+func TestOpenCodeRenderer_InstallWorkflow_RegistryNotCaptured(t *testing.T) {
 	projectRoot := t.TempDir()
 	workspaceRoot := filepath.Join(projectRoot, ".opencode")
 	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
@@ -706,17 +708,12 @@ components:
 		t.Fatalf("InstallWorkflow: %v", err)
 	}
 
-	// Registry content is captured in the renderer for later use by RenderRootCatalog.
+	// REGISTRY content must NOT be captured for OpenCode — primary agents own
+	// their playbook in opencode.json; AGENTS.md should not carry the workflow's
+	// orchestrator rules.
 	contents := r.RegistryContents()
-	// The workflow name "sdd" must exist as a key.
-	if _, ok := contents[wf.Metadata.Name]; !ok {
-		t.Errorf("RegistryContents should contain captured content for workflow 'sdd'; got keys: %v", func() []string {
-			var keys []string
-			for k := range contents {
-				keys = append(keys, k)
-			}
-			return keys
-		}())
+	if _, ok := contents[wf.Metadata.Name]; ok {
+		t.Errorf("RegistryContents must NOT contain workflow %q for OpenCode installs; got captured content", wf.Metadata.Name)
 	}
 
 	// NEGATIVE: REGISTRY.md must NOT exist in .agents/skills/.


### PR DESCRIPTION
## Summary

Pairs with the catalog PR that deletes \`REGISTRY.opencode.md\` / \`REGISTRY.copilot.md\` and slims \`ORCHESTRATOR.{opencode,copilot}.md\` to be the single-source orchestrator playbook.

OpenCode and Copilot have a primary \`sdd-orchestrator\` agent the user explicitly selects (custom agent in \`opencode.json\` / \`.agent.md\` in \`.github/agents/\`). That selection IS the consent to use the workflow. Until now, the renderer was also:

1. Prepending \`REGISTRY.{opencode,copilot}.md\` to the synthesised orchestrator prompt
2. Capturing the same content into \`r.registryContents\` for later injection into the ambient instructions file (AGENTS.md / copilot-instructions.md)

Both paths leaked workflow-specific rules into non-workflow sessions (ambient catalog) and duplicated / contradicted the orchestrator's own playbook (prompt prepend). They were a Claude/Factory pattern applied where it does not fit.

This change removes both consumers for OpenCode and Copilot. Claude / Factory / Codex paths are unchanged.

## Changes

- **\`opencode.go\` (RenderWorkflow)**: skip \`captureRegistryContent\` for the workflow registry; pass \`registryPath=\"\"\` to \`synthesizeAgents\`. Comment block at the call site explains why (primary-agent installs do not need REGISTRY).
- **\`opencode.go\` (buildOrchestratorEntry)**: signature unchanged for backward compatibility — non-empty \`registryPath\` is still honoured if a future caller passes one — but the canonical caller now passes \"\". Doc-comment updated.
- **\`copilot.go\`**: parallel changes — skip \`captureRegistryContent\`; pass \`registryPath=\"\"\` to \`installOrchestratorAgent\`. Same explanatory comment.

## Tests

- \`TestOpenCodeRenderer_InstallWorkflow_RegistryInjectedIntoCatalog\` → renamed to \`TestOpenCodeRenderer_InstallWorkflow_RegistryNotCaptured\`. Asserts \`RegistryContents()\` does NOT contain the workflow name. Negative assertion (no loose REGISTRY.md in skills dir) preserved.
- \`TestCopilotRenderer_InstallWorkflow_RegistryInjectedIntoCatalog\` → renamed to \`TestCopilotRenderer_InstallWorkflow_RegistryNotCaptured\`. Same flip.
- All other tests pass unchanged. \`go test ./...\` clean.

## Compatibility

The change is forward-only: a workspace that materialised before this change still has the old REGISTRY-flavoured prompt in \`opencode.json\` / \`.agent.md\` until the next \`devrune sync\`, at which point the new prompt is rendered (REGISTRY content drops out, slim ORCHESTRATOR replaces it).

A workspace running this renderer against an old catalog (one that still ships \`REGISTRY.{opencode,copilot}.md\`) simply ignores those files — no error, no leak. A workspace running the old renderer against the new catalog (which deletes them) falls back to \`REGISTRY.md\` (generic Claude flavour) for the registry path, but reads an empty file capture, so the impact is harmless.

## Pairing PR

Catalog: https://github.com/davidarce/devrune-starter-catalog/pull/new/fix/sdd-opencode-copilot-slim-orchestrator

Recommended order: merge catalog first, then this PR.

## Test plan

- [ ] \`go test ./...\` passes (already verified locally).
- [ ] Merge both PRs, then \`devrune sync\` against an OpenCode workspace.
- [ ] Verify \`opencode.json\` orchestrator prompt is the new slim ORCHESTRATOR alone (no Evaluation Gate, no \"Your Role\" defensive prose).
- [ ] Verify \`AGENTS.md\` no longer carries the SDD orchestrator section.
- [ ] Same for a Copilot install (\`.github/agents/sdd-orchestrator.agent.md\` body, \`.github/copilot-instructions.md\` ambient).